### PR TITLE
Add a `pick_file` function that prompts user for a filepath

### DIFF
--- a/osmo_jupyter/__init__.py
+++ b/osmo_jupyter/__init__.py
@@ -1,3 +1,3 @@
 from .db_access import configure_database, load_calculation_details  # noqa: F401
 from .timezone import utc_series_to_local  # noqa: F401
-from .files import pick_file
+from .files import pick_file  # noqa: F401

--- a/osmo_jupyter/__init__.py
+++ b/osmo_jupyter/__init__.py
@@ -1,2 +1,3 @@
 from .db_access import configure_database, load_calculation_details  # noqa: F401
 from .timezone import utc_series_to_local  # noqa: F401
+from .files import pick_file

--- a/osmo_jupyter/files.py
+++ b/osmo_jupyter/files.py
@@ -1,0 +1,22 @@
+def pick_file(directory):
+    # Local import as some OS's don't have tkinter built-in
+    from tkinter import Tk
+    from tkinter.filedialog import askopenfilename
+
+    root = Tk()
+
+    # Rearrange windows:
+    # `withdraw` hides the "root" window that comes up alongside the actual file dialog window
+    # `lift` and "-topmost" bring the file dialog to the front
+    root.withdraw()
+    root.lift()
+    root.attributes("-topmost", True)
+
+    filepath = askopenfilename(
+        parent=root,
+        initialdir=directory
+    )
+
+    root.destroy()  # Make sure the hidden "root" window is closed
+
+    return filepath


### PR DESCRIPTION
Code for [Separate tool to select ROIs](https://app.asana.com/0/819671808102776/901314508849883)

It turns out the only hard part of this ticket was how to select image to use for ROI selection. I thought maybe it would be best to just give technicians a file picker dialog, hence this function.

Here's how I'll demonstrate this in the jupyter snippet:
![image](https://user-images.githubusercontent.com/5770688/49838562-140ec480-fd60-11e8-877b-086b81326ae6.png)

**Open questions**
* Should I require passing in the directory in `pick_file`?. The file picker works fine without a directory, but I just worry that could lead to accidentally selecting an image from the wrong folder.
* Should I pull together the three functions in the example snippet into a single public function for convenience? This function would probably live in `process_experiment` e.g:
```
def select_ROIs(raw_images_directory):
    jpeg_file_path_for_ROI_selection = pick_file(raw_images_directory)
    rgb_image_for_ROI_selection = raw.open.as_rgb(jpeg_file_path_for_ROI_selection)
    ROI_definitions = prompt_for_ROI_selection(rgb_image_for_ROI_selection)
    return ROI_definitions
```

**Testing**
Only manual testing in jupyter notebook