### PR TITLE
DRY up documentation about source data fit

### DIFF
--- a/osmo_jupyter/simulate/do_patch.py
+++ b/osmo_jupyter/simulate/do_patch.py
@@ -7,8 +7,24 @@ from osmo_jupyter.plot.color_from_temperature import color_from_temperature
 from osmo_jupyter.simulate.do_and_temp_meshgrid import DO_DOMAIN, TEMPERATURE_DOMAIN
 
 
+FIT_SOURCE_DOCUMENTATION = '''
+---
+Details about the optical reading fit and source data:
+    Source data: Ocean Optics patch data.
+
+    Fit type: a version of the two-site model which uses arrhenius equations for temperature dependence.
+    (Note that there are a lot of ways this could be tweaked.)
+
+    As part of this, we convert DO values to partial pressure to match the partial pressure unit used in the
+    legacy fit.
+
+    README for where this came from and with a lot of other useful info:
+    https://docs.google.com/document/d/1lBv0aumCDdCd0JDt9hPw6aIExyhNtGtN9RVu_5sQ5yA/edit
+'''
+
+
 def _get_rate_constant(temperature_c, preexponential_factor, activation_energy):
-    ''' Estimate the rate constant for a reaction using an Arrhenius equation
+    '''Estimate the rate constant for a reaction using an Arrhenius equation
     https://en.wikipedia.org/wiki/Arrhenius_equation#Equation
 
     General form:
@@ -25,12 +41,7 @@ def _get_rate_constant(temperature_c, preexponential_factor, activation_energy):
 
 
 def _estimate_optical_reading(do_pct_sat, temperature_c):
-    ''' This is a fit which worked pretty well with Ocean Optix patch data.
-    It's a version of the two-site model which uses arrhenius equations for temperature dependence.
-    Note that there are a lot of ways this could be tweaked.
-
-    README for where this came from and with a lot of other useful info:
-    https://docs.google.com/document/d/1lBv0aumCDdCd0JDt9hPw6aIExyhNtGtN9RVu_5sQ5yA/edit
+    '''Estimate an optical reading given `do_pct_sat` and `temperature_c`, using a precalculated, hardcoded fit.
     '''
     # First-pass fit params with ocean optics data using scipy.optimize.curve_fit.
     k_p_f = 7.818e-01
@@ -52,12 +63,13 @@ def _estimate_optical_reading(do_pct_sat, temperature_c):
     return i0 * f / (1 + ka * do_pct_of_760mmhg) + (1 - f) * i0 / (1 + kb * do_pct_of_760mmhg)
 
 
-def get_optical_reading_normalized(do_pct_sat, temperature, min_value=0, max_value=1):
-    ''' Get an optical reading between a min and max value, with a DO and temperature relationship closely
-    matching that seen in our patches in the past.
+# Dynamically update the __doc__ to include the FIT_SOURCE_DOCUMENTATION
+_estimate_optical_reading.__doc__ += FIT_SOURCE_DOCUMENTATION
 
-    This function also converts DO values to partial pressure to deal with the partial pressure unit used in the
-    legacy fit.
+
+def get_optical_reading_normalized(do_pct_sat, temperature, min_value=0, max_value=1):
+    '''Get a normalized optical reading between a min and max value, with DO and temperature relationship from a
+    precalculated, hardcoded fit.
 
     Args:
         do_pct_sat: Dissolved Oxygen in percent saturation
@@ -97,8 +109,14 @@ def get_optical_reading_normalized(do_pct_sat, temperature, min_value=0, max_val
     return normalized_optical_reading * range_ + min_value
 
 
+# Dynamically update the __doc__ to include the FIT_SOURCE_DOCUMENTATION
+get_optical_reading_normalized.__doc__ += FIT_SOURCE_DOCUMENTATION
+
+
 def get_optical_reading_plot():
-    ''' Quick plot of a single-patch optical reading over a range of temperatures and DO values. '''
+    '''Quick plot of a single-patch optical reading over a range of temperatures and DO values, using
+    a precalculated, hardcoded fit.
+    '''
     temperatures_to_plot = TEMPERATURE_DOMAIN[::5]
 
     return go.FigureWidget(
@@ -121,3 +139,7 @@ def get_optical_reading_plot():
             'yaxis': {'title': 'Optical reading (normalized max=1/min=0)'}
         }
     )
+
+
+# Dynamically update the __doc__ to include the FIT_SOURCE_DOCUMENTATION
+get_optical_reading_plot.__doc__ += FIT_SOURCE_DOCUMENTATION

--- a/osmo_jupyter/simulate/do_patch.py
+++ b/osmo_jupyter/simulate/do_patch.py
@@ -7,10 +7,14 @@ from osmo_jupyter.plot.color_from_temperature import color_from_temperature
 from osmo_jupyter.simulate.do_and_temp_meshgrid import DO_DOMAIN, TEMPERATURE_DOMAIN
 
 
+# Sharing docstring content - note that this has to be shared via mutating a function's `__doc__` attribute.
+# This is because the mechanism that defines __doc__ in the first place doesn't support addition or f-strings.
+# For more exciting detail, check out https://bugs.python.org/issue28739.
 FIT_SOURCE_DOCUMENTATION = '''
 ---
 Details about the optical reading fit and source data:
-    Source data: Ocean Optics patch data.
+    Source data: Ocean Optics calibration data measuriung fluorescence decay (tau). We expect fluorescent decay
+    to be directly proportional to fluorescence intensity across DO and temperature values
 
     Fit type: a version of the two-site model which uses arrhenius equations for temperature dependence.
     (Note that there are a lot of ways this could be tweaked.)
@@ -63,7 +67,6 @@ def _estimate_optical_reading(do_pct_sat, temperature_c):
     return i0 * f / (1 + ka * do_pct_of_760mmhg) + (1 - f) * i0 / (1 + kb * do_pct_of_760mmhg)
 
 
-# Dynamically update the __doc__ to include the FIT_SOURCE_DOCUMENTATION
 _estimate_optical_reading.__doc__ += FIT_SOURCE_DOCUMENTATION
 
 
@@ -109,7 +112,6 @@ def get_optical_reading_normalized(do_pct_sat, temperature, min_value=0, max_val
     return normalized_optical_reading * range_ + min_value
 
 
-# Dynamically update the __doc__ to include the FIT_SOURCE_DOCUMENTATION
 get_optical_reading_normalized.__doc__ += FIT_SOURCE_DOCUMENTATION
 
 
@@ -141,5 +143,4 @@ def get_optical_reading_plot():
     )
 
 
-# Dynamically update the __doc__ to include the FIT_SOURCE_DOCUMENTATION
 get_optical_reading_plot.__doc__ += FIT_SOURCE_DOCUMENTATION

--- a/osmo_jupyter/simulate/do_ratiometric.py
+++ b/osmo_jupyter/simulate/do_ratiometric.py
@@ -1,7 +1,7 @@
 import plotly.graph_objs as go
 
 from osmo_jupyter.plot.color_from_temperature import color_from_temperature
-from osmo_jupyter.simulate.do_patch import get_optical_reading_normalized
+from osmo_jupyter.simulate.do_patch import get_optical_reading_normalized, FIT_SOURCE_DOCUMENTATION
 from osmo_jupyter.simulate.do_and_temp_meshgrid import DO_DOMAIN, TEMPERATURE_DOMAIN
 
 
@@ -22,7 +22,7 @@ def simulate_spatial_ratiometric_reading(
         unsealed_patch_kwargs: Optional. Additional args passed to get_optical_reading_normalized for the unsealed patch
 
     Returns:
-        An optical reading normalized to be within (optional) min_value and max_value.
+        A spatial ratiometric result: the ratio between normalized optical readings of the unsealed and sealed patches
     '''
 
     unsealed_patch_reading = get_optical_reading_normalized(
@@ -36,6 +36,9 @@ def simulate_spatial_ratiometric_reading(
         **sealed_patch_kwargs
     )
     return unsealed_patch_reading / sealed_patch_reading
+
+
+simulate_spatial_ratiometric_reading.__doc__ += FIT_SOURCE_DOCUMENTATION
 
 
 def get_ratiometric_reading_plot():
@@ -62,3 +65,6 @@ def get_ratiometric_reading_plot():
             'yaxis': {'title': 'Spatial Ratiometric Reading (unitless)'}
         }
     )
+
+
+get_ratiometric_reading_plot.__doc__ += FIT_SOURCE_DOCUMENTATION


### PR DESCRIPTION
Jacob requested that the docstrings of various functions include details about the source data and fit.

What it looks like:
![image](https://user-images.githubusercontent.com/5770688/56051917-f1d48580-5d04-11e9-8dc3-6b3ed3d95a18.png)
