### PR TITLE
Add uniform dataframe sampler

### DIFF
--- a/osmo_jupyter/sample.py
+++ b/osmo_jupyter/sample.py
@@ -23,13 +23,16 @@ def uniform(dataframe, columns_and_bin_counts):
     )
 
     # Combine all bins for each row into one series of n-dimensional bins
-    bins = binned.apply(tuple, 1)
+    combined_bins = binned.apply(tuple, axis=1)
 
     # Take samples from each bin
-    samples_per_bin = bins.value_counts().min()
-    samples_index = bins.groupby(bins).apply(
+    samples_per_bin = combined_bins.value_counts().min()
+    samples_index = combined_bins.groupby(
+        combined_bins,
+        group_keys=False
+    ).apply(
         lambda bin_group:
             bin_group.sample(samples_per_bin)
-    ).index.levels[1].values
+    ).index
 
     return dataframe.loc[samples_index]

--- a/osmo_jupyter/sample.py
+++ b/osmo_jupyter/sample.py
@@ -1,37 +1,35 @@
-import numpy as np
 import pandas as pd
 
 
-def uniform(dataframe, columns, bin_counts):
+def uniform(dataframe, columns_and_bin_counts):
     '''
     Uniformly sample a DataFrame across n-dimensions.
 
     Args:
         dataframe: A pandas DataFrame
-        columns: A list of columns names to sample uniformly
-        bin_counts: A list of the number of bins over which to distribute each column
-        Number of bins are assigned positionally to their respective column
+        columns_and_bin_counts: A dictionary of columns names and the number of bins
+            over which to distribute each column
 
     Returns:
         A pandas DataFrame with a uniform distribution across the specified columns
     '''
 
-    # Create n-dimensional histogram of requested columns
-    histogram = pd.DataFrame(
-        [
-            pd.cut(dataframe[columns[i]], bin_counts[i], labels=range(0, bin_counts[i]))
-            for i in range(0, len(columns))
-        ],
-    ).transpose()
-    histogram.index = dataframe.index.copy()
-    # Combine all bins into one n-dimensional bin
-    histogram['bin'] = pd.Categorical(histogram.apply(tuple, 1))
+    # Create bins for each requested columns
+    binned = pd.DataFrame(
+        {
+            column: pd.cut(dataframe[column], bin_count)
+            for column, bin_count in columns_and_bin_counts.items()
+        },
+    )
 
-    max_samples = histogram['bin'].value_counts().min()
-    samples = [
-        histogram[histogram['bin'].astype(object) == bin].sample(max_samples).index.values
-        for bin in histogram['bin'].unique()
-    ]
+    # Combine all bins for each row into one series of n-dimensional bins
+    bins = binned.apply(tuple, 1)
 
-    index = np.array(samples).flatten()
-    return dataframe.loc[index]
+    # Take samples from each bin
+    samples_per_bin = bins.value_counts().min()
+    samples_index = bins.groupby(bins).apply(
+        lambda bin_group:
+            bin_group.sample(samples_per_bin)
+    ).index.levels[1].values
+
+    return dataframe.loc[samples_index]

--- a/osmo_jupyter/sample.py
+++ b/osmo_jupyter/sample.py
@@ -1,0 +1,37 @@
+import numpy as np
+import pandas as pd
+
+
+def uniform(dataframe, columns, bin_counts):
+    '''
+    Uniformly sample a DataFrame across n-dimensions.
+
+    Args:
+        dataframe: A pandas DataFrame
+        columns: A list of columns names to sample uniformly
+        bin_counts: A list of the number of bins over which to distribute each column
+        Number of bins are assigned positionally to their respective column
+
+    Returns:
+        A pandas DataFrame with a uniform distribution across the specified columns
+    '''
+
+    # Create n-dimensional histogram of requested columns
+    histogram = pd.DataFrame(
+        [
+            pd.cut(dataframe[columns[i]], bin_counts[i], labels=range(0, bin_counts[i]))
+            for i in range(0, len(columns))
+        ],
+    ).transpose()
+    histogram.index = dataframe.index.copy()
+    # Combine all bins into one n-dimensional bin
+    histogram['bin'] = pd.Categorical(histogram.apply(tuple, 1))
+
+    max_samples = histogram['bin'].value_counts().min()
+    samples = [
+        histogram[histogram['bin'].astype(object) == bin].sample(max_samples).index.values
+        for bin in histogram['bin'].unique()
+    ]
+
+    index = np.array(samples).flatten()
+    return dataframe.loc[index]

--- a/osmo_jupyter/sample_test.py
+++ b/osmo_jupyter/sample_test.py
@@ -28,8 +28,10 @@ class TestSampleUniform(object):
             },
         )
 
-        expected_distribution = np.full(num_bins, 1 / num_bins)
+        # Use normalized value_counts to get the distribution of values in column 'one'
         actual_distribution = output_dataframe['one'].value_counts(normalize=True).values
+        # Create an array of expected value count distribution in column 'one'
+        expected_distribution = np.full(num_bins, 1 / num_bins)
 
         np.testing.assert_almost_equal(actual_distribution, expected_distribution)
 
@@ -43,10 +45,12 @@ class TestSampleUniform(object):
             },
         )
 
+        # Use normalized value_counts to get the distribution of values in column 'one'
+        actual_distribution = output_dataframe['one'].value_counts(normalize=True).values
+        # Expect the number of bins to saturate to the number of unique values instead of
+        # creating a large number of empty bins between max and min values in the column
         unique_values_count = len(self.small_test_dataframe['one'].unique())
         expected_distribution = np.full(unique_values_count, 1 / unique_values_count)
-
-        actual_distribution = output_dataframe['one'].value_counts(normalize=True).values
 
         np.testing.assert_almost_equal(actual_distribution, expected_distribution)
 
@@ -55,6 +59,7 @@ class TestSampleUniform(object):
         num_columns = 10
         columns = [f'column_{n}' for n in range(0, num_columns)]
         columns_to_balance = columns[0:4]
+
         input_dataframe = pd.DataFrame(
             np.random.rand(10000, num_columns),
             columns=columns
@@ -70,6 +75,7 @@ class TestSampleUniform(object):
         expected_distribution = np.full(num_bins, 1 / num_bins)
 
         for column in columns_to_balance:
+            # Use pd.cut to bin the given column, then get normalized bin counts
             actual_distribution = pd.cut(
                 output_dataframe[column],
                 num_bins
@@ -97,6 +103,7 @@ class TestSampleUniform(object):
             }
         )
 
+        # Ensure the output rows are still assigned to the correct index value
         pd.testing.assert_frame_equal(
             input_dataframe.loc[output_dataframe.index],
             output_dataframe

--- a/osmo_jupyter/sample_test.py
+++ b/osmo_jupyter/sample_test.py
@@ -1,0 +1,71 @@
+import numpy as np
+import pandas as pd
+
+import osmo_jupyter.sample as module
+
+
+class TestSampleUniform(object):
+    small_test_dataframe = pd.DataFrame(
+        [
+            (1, 1), (1, 2), (1, 3), (1, 4),
+            (2, 1), (2, 2), (2, 3), (2, 4),
+            (3, 1), (3, 2), (3, 3), (3, 4),
+            (4, 1), (4, 2), (4, 3), (4, 4),
+
+            (1, 1), (1, 1), (1, 2), (1, 2),
+        ],
+        columns=['one', 'two']
+    )
+
+    def test_uniform_in_one_dimension(self):
+        num_bins = 4
+
+        output_dataframe = module.uniform(
+            self.small_test_dataframe,
+            columns=['one'],
+            bin_counts=[num_bins]
+        )
+
+        col_1_distribution = output_dataframe['one'].value_counts(normalize=True).values
+        np.testing.assert_almost_equal(col_1_distribution, np.full(num_bins, 1 / num_bins))
+
+    def test_uniform_with_extra_bins(self):
+        num_bins = 4000
+
+        output_dataframe = module.uniform(
+            self.small_test_dataframe,
+            columns=['one'],
+            bin_counts=[num_bins]
+        )
+
+        num_unique = len(self.small_test_dataframe['one'].unique())
+        col_1_distribution = output_dataframe['one'].value_counts(normalize=True).values
+        np.testing.assert_almost_equal(col_1_distribution, np.full(num_unique, 1 / num_unique))
+
+    def test_uniform_in_multiple_dimensions(self):
+        num_bins = 7
+        num_columns = 10
+        columns = [f'column_{n}' for n in range(0, num_columns)]
+        columns_to_balance = columns[0:4]
+        input_dataframe = pd.DataFrame(
+            np.random.rand(10000, num_columns),
+            columns=columns
+        )
+
+        output_dataframe = module.uniform(
+            input_dataframe,
+            columns=columns_to_balance,
+            bin_counts=[num_bins] * len(columns_to_balance)
+        )
+
+        for column in columns_to_balance:
+            distribution = pd.cut(
+                output_dataframe[column],
+                num_bins
+            ).value_counts(normalize=True).values
+
+            np.testing.assert_almost_equal(
+                distribution,
+                np.full(num_bins, 1 / num_bins),
+                decimal=2
+            )


### PR DESCRIPTION
[Asana Ticket](https://app.asana.com/0/819671808102776/1125039984561184)

Adds a helper function to sample a given DataFrame uniformly across n-columns. Useful for balancing an ML dataset in e.g. DO and temperature values, with minimal lost data points.