### PR TITLE
Add bin_quantile parameter to uniform sampler

### DIFF
--- a/osmo_jupyter/sample.py
+++ b/osmo_jupyter/sample.py
@@ -9,6 +9,8 @@ def uniform(dataframe, columns_and_bin_counts, bin_quantile=0):
         dataframe: A pandas DataFrame
         columns_and_bin_counts: A dictionary of columns names and the number of bins
             over which to distribute each column
+        bin_quantile: The lowest quantile of the combined bin sizes to use to determine
+            the number of samples to take from each bin. Defaults to 0.
 
     Returns:
         A pandas DataFrame with a uniform distribution across the specified columns

--- a/osmo_jupyter/sample.py
+++ b/osmo_jupyter/sample.py
@@ -10,7 +10,7 @@ def uniform(dataframe, columns_and_bin_counts, bin_quantile=0):
         columns_and_bin_counts: A dictionary of columns names and the number of bins
             over which to distribute each column
         bin_quantile: The lowest quantile of the combined bin sizes to use to determine
-            the number of samples to take from each bin. Defaults to 0.
+            the number of samples to take from each bin. Defaults to 0. Empty bins are ignored.
 
     Returns:
         A pandas DataFrame with a uniform distribution across the specified columns
@@ -34,6 +34,8 @@ def uniform(dataframe, columns_and_bin_counts, bin_quantile=0):
         group_keys=False
     ).apply(
         lambda bin_group:
+            # Use min() to ensure sample doesn't throw in the event
+            # samples_per_bin is larger than the number of samples possible
             bin_group.sample(min(samples_per_bin, len(bin_group)))
     ).index
 

--- a/osmo_jupyter/sample.py
+++ b/osmo_jupyter/sample.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
 
-def uniform(dataframe, columns_and_bin_counts):
+def uniform(dataframe, columns_and_bin_counts, bin_quantile=0):
     '''
     Uniformly sample a DataFrame across n-dimensions.
 
@@ -26,13 +26,13 @@ def uniform(dataframe, columns_and_bin_counts):
     combined_bins = binned.apply(tuple, axis=1)
 
     # Take samples from each bin
-    samples_per_bin = combined_bins.value_counts().min()
+    samples_per_bin = combined_bins.value_counts().quantile(bin_quantile).astype(int)
     samples_index = combined_bins.groupby(
         combined_bins,
         group_keys=False
     ).apply(
         lambda bin_group:
-            bin_group.sample(samples_per_bin)
+            bin_group.sample(min(samples_per_bin, len(bin_group)))
     ).index
 
     return dataframe.loc[samples_index]


### PR DESCRIPTION
[Asana Ticket](https://app.asana.com/0/819671808102776/1125039984561184)

This is an optimization on top of #26, aimed at being less sensitive to outlier data in favor of preserving more data in the output uniform sample.

This adds an optional `bin_quantile` parameter which is used to select the `samples_per_bin` value based on the distribution of the combined bin counts. E.g. `bin_quantile=0.1` will ignore the smallest 10% of bins when determining sample size.

## Manual Testing
See "2019-06-13 Distributions and bins exploration" notebook in [2019-06-13 Distributions and bins exploration](https://drive.google.com/drive/u/0/folders/1m35QHVJaImQKVZgSHL_4OOovK-Cnm2tl) for some example performance against our ml dataset.