### PR TITLE
JFFI: Consolidate configuration into tox.ini.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,0 @@
-[flake8]
-exclude = .git,__pycache__,.eggs,.pytest_cache,build,dist,lib
-max_line_length = 120
-ignore = W503,E203
-
-[tool:pytest]
-addopts = --flake8 --black

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ commands =
 
 [flake8]
 exclude = .git,__pycache__,.eggs,.pytest_cache,build,dist,lib
-max_line_length = 10
+max_line_length = 120
 ignore = W503,E203
 
 [pytest]

--- a/tox.ini
+++ b/tox.ini
@@ -11,3 +11,11 @@ deps =
     -rtest_requirements.txt
 commands =
     pytest []
+
+[flake8]
+exclude = .git,__pycache__,.eggs,.pytest_cache,build,dist,lib
+max_line_length = 10
+ignore = W503,E203
+
+[pytest]
+addopts = --flake8 --black


### PR DESCRIPTION
pytest and flake8 already look there, so why not?

Plus there is an issue with atom in particular where for some reason, flake8 does not look in setup.cfg for configuration.