### PR TITLE
JFFI: upgrade plotly to v4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         "numpy",
         "pandas",
         "petl",
-        "plotly >= 3, < 4",
+        "plotly >= 4, < 5",
         "pymysql",
         "requests",
         "scipy",


### PR DESCRIPTION
No asana.

### Why I think this is a good idea

plotly V4 provides direct access to the plotly_express package which is super convenient. It also makes several other nice changes.

### Why I think it's safe

I have run a few recent notebooks with plotly v4, and skimmed the [migration guide](https://plot.ly/python/v4-migration/) and I don't think any of the breaking changes will affect us in our recent notebooks. If they do (most likely we're making now-unnecessary `plotly.offline.init_notebook_mode()` calls in some old notebooks) then it'll be trivial to update notebooks when we update the notebook's version of osmo-jupyter.

### What changes to expect

mostly a new default theme and access to `plotly_express` without installing a separate package.