### PR TITLE
Add tools for processing calibration data

### DIFF
--- a/osmo_jupyter/dataset.py
+++ b/osmo_jupyter/dataset.py
@@ -1,0 +1,202 @@
+import os
+from typing import List
+
+import numpy as np
+import pandas as pd
+
+
+def _interpolate_and_join_data(df_1: pd.DataFrame, df_2: pd.DataFrame) -> pd.DataFrame:
+    # Upsample df_1 to every second to allow any timestamp to be joined on a strict match
+    resampled_df_1 = df_1.resample("s").interpolate(method="slinear")
+
+    return df_2.join(  # By default join happens on index values
+        resampled_df_1, how="inner"  # Drop any rows without a match in both DataFrames
+    )
+
+
+def open_picolog_file(picolog_filepath):
+    return (
+        pd.read_csv(
+            picolog_filepath,
+            index_col=0,  # first column, is unlabeled
+            parse_dates=[0],  # first column
+            date_parser=lambda col: pd.to_datetime(col, utc=False).tz_localize(
+                None
+            ),  # Remove timezone information
+        )
+        .rename_axis("timestamp")
+        .add_prefix("PicoLog ")
+    )
+
+
+def open_calibration_log_file(calibration_log_filepath):
+    return pd.read_csv(
+        calibration_log_filepath,
+        index_col="timestamp",
+        parse_dates=["timestamp"],
+        date_parser=lambda col: pd.to_datetime(col, utc=False).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        ),  # Truncate fractional seconds
+    )
+
+
+def open_and_combine_picolog_and_calibration_data(
+    calibration_log_filepaths: List[str], picolog_log_filepaths: List[str]
+) -> pd.DataFrame:
+    picolog_data = pd.concat(
+        [
+            open_picolog_file(picolog_filepath)
+            for picolog_filepath in picolog_log_filepaths
+        ],
+        sort=True,
+    )
+
+    calibration_data = pd.concat(
+        [
+            open_calibration_log_file(calibration_log_filepath)
+            for calibration_log_filepath in calibration_log_filepaths
+        ],
+        sort=True,
+    )
+
+    return _interpolate_and_join_data(picolog_data, calibration_data)
+
+
+def get_equilibration_boundaries(equilibration_status: pd.Series) -> pd.DataFrame:
+    # Get a boolean series with timestamped index of equilbrated data points
+    equilibrated_mask = equilibration_status == "equilibrated"
+
+    # Upsample to every second
+    equilibration_status_sampler = equilibrated_mask.astype(int).resample("s")
+
+    # In order to not interpolate any gaps around equilibrated states as also equilibrated, interpolate
+    # state as an integer (True == 1) and truncate any decimals (e.g. 0.2 -> 0, or False)
+    interpolated_equilbration_status = equilibration_status_sampler.interpolate().apply(
+        np.floor
+    )
+
+    # rolling difference from previous row
+    leading_edges = interpolated_equilbration_status[
+        interpolated_equilbration_status.astype(int).diff() == 1
+    ].index
+    # rolling difference with next row
+    trailing_edges = interpolated_equilbration_status[
+        interpolated_equilbration_status.astype(int).diff(periods=-1) == 1
+    ].index
+
+    # Trim edges to align
+    if len(leading_edges) > len(trailing_edges):
+        leading_edges = leading_edges[:-1]
+    if len(trailing_edges) > len(leading_edges):
+        trailing_edges = trailing_edges[1:]
+
+    return pd.DataFrame(
+        {"leading_edge": leading_edges, "trailing_edge": trailing_edges}
+    )
+
+
+def pivot_process_experiment_results_on_ROI(
+    experiment_df: pd.DataFrame,
+    ROI_names: List[str] = None,
+    msorm_types: List[str] = ["r_msorm", "g_msorm", "b_msorm"],
+) -> pd.DataFrame:
+    """
+    Uses a pivot table to flatten multiple ROIs for the same image into one row.
+    Returns a DataFrame with one row per image, and msorm values for a subset of ROIs.
+    """
+    if ROI_names:
+        experiment_df = experiment_df[experiment_df["ROI"].isin(ROI_names)]
+
+    # Pivot creates a heirachical multiindex data frame with an index for each 'values' column
+    pivot = experiment_df.pivot(
+        index="timestamp", columns="ROI", values=msorm_types + ["image"]
+    )
+
+    # There's one copy of the image name for each ROI due to the pivot, so pull out the top level index
+    images = pivot["image"][experiment_df["ROI"].values[0]]
+    pivot.drop("image", axis=1, inplace=True)
+    # Flatten the pivot table index, and add images back in
+    pivot.columns = [" ".join(col[::-1]).strip() for col in pivot.columns.values]
+    pivot["image"] = images
+
+    return pivot
+
+
+def open_and_combine_process_experiment_results(
+    results_filepaths: List[str],
+    ROI_names: List[str] = None,
+    msorm_types: List[str] = ["r_msorm", "g_msorm", "b_msorm"],
+) -> pd.DataFrame:
+    all_roi_data = pd.concat(
+        [
+            pd.read_csv(results_filepath, parse_dates=["timestamp"])
+            for results_filepath in results_filepaths
+        ]
+    )
+
+    return pivot_process_experiment_results_on_ROI(all_roi_data, ROI_names, msorm_types)
+
+
+def get_all_experiment_images(
+    local_sync_directory: str, experiment_names: List[str]
+) -> pd.DataFrame:
+    all_images = pd.concat(
+        [
+            pd.DataFrame(
+                {
+                    "experiment": experiment_name,
+                    "image": os.listdir(
+                        os.path.join(local_sync_directory, experiment_name)
+                    ),
+                },
+                dtype="object",  # Ensure correct dtype when no images are found
+            )
+            for experiment_name in experiment_names
+        ]
+    )
+
+    # Filter out experiment log files
+    return all_images.drop(all_images[~all_images["image"].str.contains("jpeg")].index)
+
+
+def filter_equilibrated_images(equilibration_range, image_ROI_data):
+    leading_edge_mask = image_ROI_data.index > equilibration_range["leading_edge"]
+    trailing_edge_mask = image_ROI_data.index < equilibration_range["trailing_edge"]
+    return image_ROI_data[leading_edge_mask & trailing_edge_mask]
+
+
+def open_and_combine_source_data(
+    local_sync_directory: str,
+    experiment_names: List[str],
+    calibration_log_filepaths: List[str],
+    picolog_log_filepaths: List[str],
+    results_filepaths: List[str],
+    ROI_names: List[str] = None,
+    msorm_types: List[str] = ["r_msorm", "g_msorm", "b_msorm"],
+) -> pd.DataFrame:
+
+    all_sensor_data = open_and_combine_picolog_and_calibration_data(
+        calibration_log_filepaths, picolog_log_filepaths
+    )
+
+    equilibration_boundaries = get_equilibration_boundaries(
+        all_sensor_data["equilibration status"]
+    )
+
+    all_roi_data = open_and_combine_process_experiment_results(
+        results_filepaths, ROI_names, msorm_types
+    )
+
+    equilibrated_data = pd.concat(
+        equilibration_boundaries.apply(
+            filter_equilibrated_images, axis=1, image_ROI_data=all_roi_data
+        ).values
+    ).sort_index()
+
+    all_images = get_all_experiment_images(local_sync_directory, experiment_names)
+
+    return (
+        equilibrated_data.reset_index()
+        .set_index("image")
+        .join(all_images.set_index("image"), how="inner")
+    )

--- a/osmo_jupyter/dataset.py
+++ b/osmo_jupyter/dataset.py
@@ -101,18 +101,20 @@ def get_equilibration_boundaries(equilibration_status: pd.Series) -> pd.DataFram
         equilibrated_mask.astype(int).diff(periods=-1) == 1
     ].index
 
+    # Correct single point ranges to have leading and falling edges
     if (
         len(trailing_edges)
         and len(leading_edges)
         and trailing_edges[0] < leading_edges[0]
     ):
-        trailing_edges = trailing_edges[1:]
+        # Prepend a trailing edge at the start of the dataset as its own leading edge
+        leading_edges = trailing_edges[:1].append(leading_edges)
 
     if len(trailing_edges) > len(leading_edges):
-        trailing_edges = trailing_edges[1:]
+        # use the first trailing edge as its own leading edge
+        leading_edges = leading_edges.append(trailing_edges[:1])
     if len(leading_edges) > len(trailing_edges):
         # use the final leading edge as its own trailing edge
-        # to treat the single point as an equilibrated range
         trailing_edges = trailing_edges.append(leading_edges[-1:])
 
     return pd.DataFrame({"start_time": leading_edges, "end_time": trailing_edges})

--- a/osmo_jupyter/dataset.py
+++ b/osmo_jupyter/dataset.py
@@ -119,7 +119,7 @@ def get_equilibration_boundaries(equilibration_status: pd.Series) -> pd.DataFram
 def pivot_process_experiment_results_on_ROI(
     experiment_df: pd.DataFrame,
     ROI_names: List[str] = None,
-    msorm_types: List[str] = ["r_msorm", "g_msorm", "b_msorm"],
+    msorm_types: List[str] = None,
 ) -> pd.DataFrame:
     """
         Flatten a DataFrame of process experiment results down to one row per image.
@@ -132,6 +132,9 @@ def pivot_process_experiment_results_on_ROI(
             DataFrame with one row per image, and msorm values for a subset of ROIs. Creates one column
             for every unique ROI in the dataset. NaN values are used when an image is missing an ROI.
     """
+    if msorm_types is None:
+        msorm_types = ["r_msorm", "g_msorm", "b_msorm"]
+
     if ROI_names:
         experiment_df = experiment_df[experiment_df["ROI"].isin(ROI_names)]
 
@@ -171,7 +174,7 @@ def pivot_process_experiment_results_on_ROI(
 def open_and_combine_process_experiment_results(
     process_experiment_result_filepaths: List[str],
     ROI_names: List[str] = None,
-    msorm_types: List[str] = ["r_msorm", "g_msorm", "b_msorm"],
+    msorm_types: List[str] = None,
 ) -> pd.DataFrame:
     """
         Open multiple process experiment result files and combine into a single DataFrame with one row per image.
@@ -183,6 +186,9 @@ def open_and_combine_process_experiment_results(
         Returns:
             DataFrame of all summary statistics flattened to one row per image with all selected ROIs.
     """
+    if msorm_types is None:
+        msorm_types = ["r_msorm", "g_msorm", "b_msorm"]
+
     all_roi_data = pd.concat(
         [
             pd.read_csv(results_filepath, parse_dates=["timestamp"])
@@ -242,7 +248,7 @@ def open_and_combine_and_filter_source_data(
     picolog_log_filepaths: List[str],
     process_experiment_result_filepaths: List[str],
     ROI_names: List[str] = None,
-    msorm_types: List[str] = ["r_msorm", "g_msorm", "b_msorm"],
+    msorm_types: List[str] = None,
 ) -> pd.DataFrame:
     """
         Combine and filter a collection of calibration environment, PicoLog, process experiment and image data
@@ -260,6 +266,8 @@ def open_and_combine_and_filter_source_data(
         Returns:
             DataFrame of image and sensor data collected during equilibrated states.
     """
+    if msorm_types is None:
+        msorm_types = ["r_msorm", "g_msorm", "b_msorm"]
 
     all_sensor_data = open_and_combine_picolog_and_calibration_data(
         calibration_log_filepaths, picolog_log_filepaths

--- a/osmo_jupyter/dataset.py
+++ b/osmo_jupyter/dataset.py
@@ -111,7 +111,9 @@ def get_equilibration_boundaries(equilibration_status: pd.Series) -> pd.DataFram
     if len(trailing_edges) > len(leading_edges):
         trailing_edges = trailing_edges[1:]
     if len(leading_edges) > len(trailing_edges):
-        leading_edges = leading_edges[:-1]
+        # use the final leading edge as its own trailing edge
+        # to treat the single point as an equilibrated range
+        trailing_edges = trailing_edges.append(leading_edges[-1:])
 
     return pd.DataFrame({"start_time": leading_edges, "end_time": trailing_edges})
 

--- a/osmo_jupyter/dataset_test.py
+++ b/osmo_jupyter/dataset_test.py
@@ -186,7 +186,11 @@ class TestGetEquilibrationBoundaries:
                     {
                         "start_time": pd.to_datetime("2020"),
                         "end_time": pd.to_datetime("2020"),
-                    }
+                    },
+                    {
+                        "start_time": pd.to_datetime("2022"),
+                        "end_time": pd.to_datetime("2022"),
+                    },
                 ],
             ),
             (
@@ -220,7 +224,12 @@ class TestGetEquilibrationBoundaries:
                     pd.to_datetime("2019"): "waiting",
                     pd.to_datetime("2020"): "equilibrated",
                 },
-                [],
+                [
+                    {
+                        "start_time": pd.to_datetime("2020"),
+                        "end_time": pd.to_datetime("2020"),
+                    }
+                ],
             ),
             (
                 {
@@ -228,7 +237,12 @@ class TestGetEquilibrationBoundaries:
                     pd.to_datetime("2020"): "waiting",
                     pd.to_datetime("2021"): "equilibrated",
                 },
-                [],
+                [
+                    {
+                        "start_time": pd.to_datetime("2021"),
+                        "end_time": pd.to_datetime("2021"),
+                    }
+                ],
             ),
         ],
     )

--- a/osmo_jupyter/dataset_test.py
+++ b/osmo_jupyter/dataset_test.py
@@ -170,9 +170,13 @@ class TestGetEquilibrationBoundaries:
                 },
                 [
                     {
+                        "start_time": pd.to_datetime("2020"),
+                        "end_time": pd.to_datetime("2020"),
+                    },
+                    {
                         "start_time": pd.to_datetime("2022"),
                         "end_time": pd.to_datetime("2022"),
-                    }
+                    },
                 ],
             ),
             (
@@ -217,7 +221,12 @@ class TestGetEquilibrationBoundaries:
                     pd.to_datetime("2019"): "equilibrated",
                     pd.to_datetime("2020"): "waiting",
                 },
-                [],
+                [
+                    {
+                        "start_time": pd.to_datetime("2019"),
+                        "end_time": pd.to_datetime("2019"),
+                    }
+                ],
             ),
             (
                 {
@@ -239,9 +248,13 @@ class TestGetEquilibrationBoundaries:
                 },
                 [
                     {
+                        "start_time": pd.to_datetime("2019"),
+                        "end_time": pd.to_datetime("2019"),
+                    },
+                    {
                         "start_time": pd.to_datetime("2021"),
                         "end_time": pd.to_datetime("2021"),
-                    }
+                    },
                 ],
             ),
         ],

--- a/osmo_jupyter/dataset_test.py
+++ b/osmo_jupyter/dataset_test.py
@@ -253,17 +253,15 @@ class TestFilterEquilibratedImages:
             ]
         ).set_index("timestamp")
 
-        test_equilibration_boundaries = pd.DataFrame(
-            [
-                {
-                    "start_time": pd.to_datetime("2019-01-02"),
-                    "end_time": pd.to_datetime("2019-01-04"),
-                }
-            ]
+        test_equilibration_boundaries = pd.Series(
+            {
+                "start_time": pd.to_datetime("2019-01-02"),
+                "end_time": pd.to_datetime("2019-01-04"),
+            }
         )
 
         equilibrated_image_data = module.filter_equilibrated_images(
-            equilibration_range=test_equilibration_boundaries.iloc[0], df=test_roi_data
+            equilibration_range=test_equilibration_boundaries, df=test_roi_data
         )
 
         expected_equilibrated_image_data = test_roi_data[1:]

--- a/osmo_jupyter/dataset_test.py
+++ b/osmo_jupyter/dataset_test.py
@@ -1,0 +1,323 @@
+import io
+
+import pandas as pd
+import pytest
+
+import osmo_jupyter.dataset as module
+
+TEST_PICOLOG_DATA = pd.DataFrame(
+    [
+        {"timestamp": "2019-01-01T00:00:00-07:00", "Temperature Ave. (C)": 39},
+        {"timestamp": "2019-01-01T00:00:02-07:00", "Temperature Ave. (C)": 40},
+        {"timestamp": "2019-01-01T00:00:04-07:00", "Temperature Ave. (C)": 40},
+    ]
+)
+
+TEST_CALIBRATION_DATA = pd.DataFrame(
+    [
+        {"timestamp": "2019-01-01 00:00:00.1", "equilibration status": "waiting"},
+        {"timestamp": "2019-01-01 00:00:01.1", "equilibration status": "equilibrated"},
+        {"timestamp": "2019-01-01 00:00:03.1", "equilibration status": "equilibrated"},
+        {"timestamp": "2019-01-01 00:00:04.1", "equilibration status": "waiting"},
+    ]
+)
+
+
+TEST_PROCESS_EXPERIMENT_DATA = pd.DataFrame(
+    [
+        {
+            "timestamp": pd.to_datetime("2019-01-01 00:00:00"),
+            "image": "image-0.jpeg",
+            "ROI": "ROI 0",
+            "r_msorm": 0.5,
+            "g_msorm": 0.4,
+        },
+        {
+            "timestamp": pd.to_datetime("2019-01-01 00:00:00"),
+            "image": "image-0.jpeg",
+            "ROI": "ROI 1",
+            "r_msorm": 0.4,
+            "g_msorm": 0.5,
+        },
+        {
+            "timestamp": pd.to_datetime("2019-01-01 00:00:02"),
+            "image": "image-1.jpeg",
+            "ROI": "ROI 0",
+            "r_msorm": 0.3,
+            "g_msorm": 0.6,
+        },
+        {
+            "timestamp": pd.to_datetime("2019-01-01 00:00:02"),
+            "image": "image-1.jpeg",
+            "ROI": "ROI 1",
+            "r_msorm": 0.6,
+            "g_msorm": 0.3,
+        },
+    ]
+)
+
+
+@pytest.fixture
+def mock_picolog_file_obj():
+    test_picolog_file = io.StringIO()
+    TEST_PICOLOG_DATA.to_csv(test_picolog_file, index=False)
+    test_picolog_file.seek(0)
+
+    return test_picolog_file
+
+
+@pytest.fixture
+def mock_calibration_file_obj():
+    test_calibration_env_file = io.StringIO()
+    TEST_CALIBRATION_DATA.to_csv(test_calibration_env_file, index=False)
+    test_calibration_env_file.seek(0)
+
+    return test_calibration_env_file
+
+
+class TestOpenAndCombineSensorData:
+    def test_parses_picolog_timestamps_correctly(self, mock_picolog_file_obj):
+        picolog_data = module.open_picolog_file(mock_picolog_file_obj)
+
+        assert len(picolog_data)
+        assert picolog_data.index[0] == pd.to_datetime("2019-01-01 00:00:00")
+
+    def test_parses_calibration_log_timestampes_correctly(
+        self, mock_calibration_file_obj
+    ):
+        calibration_log_data = module.open_calibration_log_file(
+            mock_calibration_file_obj
+        )
+
+        assert len(calibration_log_data)
+        assert calibration_log_data.index[0] == pd.to_datetime("2019-01-01 00:00:00")
+
+    def test_interpolates_data_correctly(
+        self, mock_calibration_file_obj, mock_picolog_file_obj
+    ):
+        combined_data = module.open_and_combine_picolog_and_calibration_data(
+            calibration_log_filepaths=[mock_calibration_file_obj],
+            picolog_log_filepaths=[mock_picolog_file_obj],
+        ).reset_index()  # move timestamp index to a column
+
+        expected_interpolation = pd.DataFrame(
+            [
+                {
+                    "timestamp": "2019-01-01 00:00:00",
+                    "equilibration status": "waiting",
+                    "PicoLog Temperature Ave. (C)": 39,
+                },
+                {
+                    "timestamp": "2019-01-01 00:00:01",
+                    "equilibration status": "equilibrated",
+                    "PicoLog Temperature Ave. (C)": 39.5,
+                },
+                {
+                    "timestamp": "2019-01-01 00:00:03",
+                    "equilibration status": "equilibrated",
+                    "PicoLog Temperature Ave. (C)": 40,
+                },
+                {
+                    "timestamp": "2019-01-01 00:00:04",
+                    "equilibration status": "waiting",
+                    "PicoLog Temperature Ave. (C)": 40,
+                },
+            ]
+        ).astype(
+            combined_data.dtypes
+        )  # coerce datatypes to match
+
+        pd.testing.assert_frame_equal(combined_data, expected_interpolation)
+
+
+class TestGetEquilibrationBoundaries:
+    def test_finds_correct_edges(self, mock_calibration_file_obj):
+        calibration_log_data = module.open_calibration_log_file(
+            mock_calibration_file_obj
+        )
+
+        parsed_equilibration_boundaries = module.get_equilibration_boundaries(
+            equilibration_status=calibration_log_data["equilibration status"]
+        )
+
+        expected_equilibration_boundaries = pd.DataFrame(
+            [
+                {
+                    "leading_edge": pd.to_datetime("2019-01-01 00:00:01"),
+                    "trailing_edge": pd.to_datetime("2019-01-01 00:00:03"),
+                }
+            ]
+        )
+
+        pd.testing.assert_frame_equal(
+            parsed_equilibration_boundaries, expected_equilibration_boundaries
+        )
+
+    def test_corrects_for_extra_rising_edge(self, mock_calibration_file_obj):
+        calibration_log_with_hanging_equilibrated_point = pd.concat(
+            [
+                module.open_calibration_log_file(mock_calibration_file_obj),
+                pd.DataFrame(
+                    [
+                        {
+                            "timestamp": pd.to_datetime("2019-01-01 00:05"),
+                            "setpoint O2 fraction": 0.2,
+                            "equilibration status": "equilibrated",
+                        }
+                    ]
+                ).set_index("timestamp"),
+            ],
+            sort=False,
+        )
+
+        parsed_equilibration_boundaries = module.get_equilibration_boundaries(
+            equilibration_status=calibration_log_with_hanging_equilibrated_point[
+                "equilibration status"
+            ]
+        )
+
+        expected_equilibration_boundaries = pd.DataFrame(
+            [
+                {
+                    "leading_edge": pd.to_datetime("2019-01-01 00:00:01"),
+                    "trailing_edge": pd.to_datetime("2019-01-01 00:00:03"),
+                }
+            ]
+        )
+
+        pd.testing.assert_frame_equal(
+            parsed_equilibration_boundaries, expected_equilibration_boundaries
+        )
+
+
+class TestPivotProcessExperimentResults:
+    def test_combines_image_rows_by_ROI(self):
+        pivot_results = module.pivot_process_experiment_results_on_ROI(
+            experiment_df=TEST_PROCESS_EXPERIMENT_DATA,
+            ROI_names=list(TEST_PROCESS_EXPERIMENT_DATA["ROI"].unique()),
+            msorm_types=["r_msorm", "g_msorm"],
+        )
+
+        expected_results_data = (
+            pd.DataFrame(
+                [
+                    {
+                        "timestamp": pd.to_datetime("2019-01-01 00:00:00"),
+                        "ROI 0 r_msorm": 0.5,
+                        "ROI 1 r_msorm": 0.4,
+                        "ROI 0 g_msorm": 0.4,
+                        "ROI 1 g_msorm": 0.5,
+                        "image": "image-0.jpeg",
+                    },
+                    {
+                        "timestamp": pd.to_datetime("2019-01-01 00:00:02"),
+                        "ROI 0 r_msorm": 0.3,
+                        "ROI 1 r_msorm": 0.6,
+                        "ROI 0 g_msorm": 0.6,
+                        "ROI 1 g_msorm": 0.3,
+                        "image": "image-1.jpeg",
+                    },
+                ]
+            )
+            .set_index("timestamp")
+            .astype(pivot_results.dtypes)
+        )
+
+        pd.testing.assert_frame_equal(pivot_results, expected_results_data)
+
+
+class TestGetAllExperimentImages:
+    def test_returns_only_image_files(self, mocker):
+        image_file_name = "image-0.jpeg"
+        experiment_name = "test"
+
+        mocker.patch("os.listdir", return_value=[image_file_name, "experiment.log"])
+
+        experiment_images = module.get_all_experiment_images(
+            local_sync_directory="", experiment_names=[experiment_name]
+        )
+
+        expected_images = pd.DataFrame(
+            [{"experiment": experiment_name, "image": image_file_name}]
+        )
+
+        pd.testing.assert_frame_equal(experiment_images, expected_images)
+
+
+class TestFilterEquilibratedImages:
+    def test_returns_only_equilibrated_images(self, mock_calibration_file_obj):
+        test_roi_data = pd.DataFrame(
+            [
+                {"timestamp": pd.to_datetime("2019-01-01"), "image": "image-0.jpeg"},
+                {"timestamp": pd.to_datetime("2019-01-03"), "image": "image-1.jpeg"},
+            ]
+        ).set_index("timestamp")
+
+        test_equilibration_boundaries = pd.DataFrame(
+            [
+                {
+                    "leading_edge": pd.to_datetime("2019-01-02"),
+                    "trailing_edge": pd.to_datetime("2019-01-04"),
+                }
+            ]
+        )
+
+        equilibrated_image_data = module.filter_equilibrated_images(
+            test_equilibration_boundaries.iloc[0], test_roi_data
+        )
+
+        expected_equilibrated_image_data = test_roi_data[1:]
+
+        pd.testing.assert_frame_equal(
+            equilibrated_image_data, expected_equilibrated_image_data
+        )
+
+
+class TestOpenAndCombineSourceData:
+    def test_filters_all_data_to_equilibrated_states(
+        self, mocker, mock_calibration_file_obj, mock_picolog_file_obj
+    ):
+        test_files = ["image-0.jpeg", "image-1.jpeg", "experiment.log"]
+        mocker.patch("os.listdir", return_value=test_files)
+
+        mocker.patch.object(
+            module,
+            "open_and_combine_process_experiment_results",
+            return_value=module.pivot_process_experiment_results_on_ROI(
+                experiment_df=TEST_PROCESS_EXPERIMENT_DATA,
+                ROI_names=list(TEST_PROCESS_EXPERIMENT_DATA["ROI"].unique()),
+                msorm_types=["r_msorm", "g_msorm"],
+            ),
+        )
+
+        experiment_name = "test"
+
+        equilibrated_experiment_data = module.open_and_combine_source_data(
+            local_sync_directory="",
+            experiment_names=[experiment_name],
+            calibration_log_filepaths=[mock_calibration_file_obj],
+            picolog_log_filepaths=[mock_picolog_file_obj],
+            results_filepaths=[],
+        )
+
+        expected_experiment_data = (
+            pd.DataFrame(
+                [
+                    {
+                        "timestamp": pd.to_datetime("2019-01-01 00:00:02"),
+                        "ROI 0 r_msorm": 0.3,
+                        "ROI 1 r_msorm": 0.6,
+                        "ROI 0 g_msorm": 0.6,
+                        "ROI 1 g_msorm": 0.3,
+                        "image": "image-1.jpeg",
+                        "experiment": experiment_name,
+                    }
+                ]
+            )
+            .set_index("image")
+            .astype(equilibrated_experiment_data.dtypes)
+        )
+
+        pd.testing.assert_frame_equal(
+            equilibrated_experiment_data, expected_experiment_data
+        )

--- a/osmo_jupyter/dataset_test.py
+++ b/osmo_jupyter/dataset_test.py
@@ -143,8 +143,8 @@ class TestGetEquilibrationBoundaries:
         expected_equilibration_boundaries = pd.DataFrame(
             [
                 {
-                    "leading_edge": pd.to_datetime("2019-01-01 00:00:01"),
-                    "trailing_edge": pd.to_datetime("2019-01-01 00:00:03"),
+                    "start_time": pd.to_datetime("2019-01-01 00:00:01"),
+                    "end_time": pd.to_datetime("2019-01-01 00:00:03"),
                 }
             ]
         )
@@ -179,8 +179,8 @@ class TestGetEquilibrationBoundaries:
         expected_equilibration_boundaries = pd.DataFrame(
             [
                 {
-                    "leading_edge": pd.to_datetime("2019-01-01 00:00:01"),
-                    "trailing_edge": pd.to_datetime("2019-01-01 00:00:03"),
+                    "start_time": pd.to_datetime("2019-01-01 00:00:01"),
+                    "end_time": pd.to_datetime("2019-01-01 00:00:03"),
                 }
             ]
         )
@@ -256,14 +256,14 @@ class TestFilterEquilibratedImages:
         test_equilibration_boundaries = pd.DataFrame(
             [
                 {
-                    "leading_edge": pd.to_datetime("2019-01-02"),
-                    "trailing_edge": pd.to_datetime("2019-01-04"),
+                    "start_time": pd.to_datetime("2019-01-02"),
+                    "end_time": pd.to_datetime("2019-01-04"),
                 }
             ]
         )
 
         equilibrated_image_data = module.filter_equilibrated_images(
-            test_equilibration_boundaries.iloc[0], test_roi_data
+            equilibration_range=test_equilibration_boundaries.iloc[0], df=test_roi_data
         )
 
         expected_equilibrated_image_data = test_roi_data[1:]
@@ -292,12 +292,12 @@ class TestOpenAndCombineSourceData:
 
         experiment_name = "test"
 
-        equilibrated_experiment_data = module.open_and_combine_source_data(
+        equilibrated_experiment_data = module.open_and_combine_and_filter_source_data(
             local_sync_directory="",
             experiment_names=[experiment_name],
             calibration_log_filepaths=[mock_calibration_file_obj],
             picolog_log_filepaths=[mock_picolog_file_obj],
-            results_filepaths=[],
+            process_experiment_result_filepaths=[],
         )
 
         expected_experiment_data = (


### PR DESCRIPTION
[Asana Ticket](https://app.asana.com/0/819671808102776/1135264514117500)

Adds some helper tools for processing all of our various sources of data into neat datasets.
Tests feel pretty messy and coverage a little light due to the amount of mock data necessary to adequately test a lot of this functionality. 

Also open to feedback re: spitting up / renaming the module.

## Manual Testing
See some example usage on our most recent collection of data in `Move some dataset generation code into osmo-jupyter.ipynb` [here](https://drive.google.com/drive/u/0/folders/1aZ3WLY2amdifzrmaQIp_5pRbanRh2N2K)
