### PR TITLE
Bugfix: Include sensor data in dataset magic function

### DIFF
--- a/osmo_jupyter/dataset.py
+++ b/osmo_jupyter/dataset.py
@@ -273,29 +273,41 @@ def open_and_combine_and_filter_source_data(
     if msorm_types is None:
         msorm_types = ["r_msorm", "g_msorm", "b_msorm"]
 
-    all_sensor_data = open_and_combine_picolog_and_calibration_data(
-        calibration_log_filepaths, picolog_log_filepaths
+    picolog_data = pd.concat(
+        [
+            open_picolog_file(picolog_filepath)
+            for picolog_filepath in picolog_log_filepaths
+        ],
+        sort=True,
+    )
+
+    calibration_data = pd.concat(
+        [
+            open_calibration_log_file(calibration_log_filepath)
+            for calibration_log_filepath in calibration_log_filepaths
+        ],
+        sort=True,
     )
 
     equilibration_boundaries = get_equilibration_boundaries(
-        all_sensor_data["equilibration status"]
+        calibration_data["equilibration status"]
     )
 
     all_roi_data = open_and_combine_process_experiment_results(
         process_experiment_result_filepaths, ROI_names, msorm_types
     )
 
-    all_roi_and_sensor_data = all_roi_data.join(
-        # interpolate sensor data to line up with ROI data,
-        # and drop columns which don't interpolate (equilibration status)
-        all_sensor_data.resample("s").interpolate(method="slinear").dropna(axis=1),
-        how="inner",
+    all_roi_and_picolog_data = all_roi_data.join(picolog_data, how="inner")
+
+    equilibrated_sensor_data = pd.concat(
+        equilibration_boundaries.apply(
+            filter_equilibrated_images, axis=1, df=all_roi_and_picolog_data
+        ).values
     )
 
-    equilibrated_data = pd.concat(
-        equilibration_boundaries.apply(
-            filter_equilibrated_images, axis=1, df=all_roi_and_sensor_data
-        ).values
+    equilibrated_data = equilibrated_sensor_data.join(
+        calibration_data.resample("s").interpolate(method="slinear").dropna(axis=1),
+        how="inner",
     ).sort_index()
 
     all_images = get_all_experiment_images(local_sync_directory, experiment_names)

--- a/osmo_jupyter/dataset.py
+++ b/osmo_jupyter/dataset.py
@@ -257,6 +257,7 @@ def open_and_combine_and_filter_source_data(
     """
         Combine and filter a collection of calibration environment, PicoLog, process experiment and image data
         into a neat DataFrame of all images taken during periods of equilibrated temperature and dissolved oxygen.
+        PicoLog and calibration sensor data are linearly interpolated to the second to line up with image timestamps.
 
         Args:
             local_sync_directory: The local data directory, usually ~/osmo/cosmobot-data-sets

--- a/osmo_jupyter/dataset.py
+++ b/osmo_jupyter/dataset.py
@@ -285,9 +285,16 @@ def open_and_combine_and_filter_source_data(
         process_experiment_result_filepaths, ROI_names, msorm_types
     )
 
+    all_roi_and_sensor_data = all_roi_data.join(
+        # interpolate sensor data to line up with ROI data,
+        # and drop columns which don't interpolate (equilibration status)
+        all_sensor_data.resample("s").interpolate(method="slinear").dropna(axis=1),
+        how="inner",
+    )
+
     equilibrated_data = pd.concat(
         equilibration_boundaries.apply(
-            filter_equilibrated_images, axis=1, df=all_roi_data
+            filter_equilibrated_images, axis=1, df=all_roi_and_sensor_data
         ).values
     ).sort_index()
 

--- a/osmo_jupyter/dataset_test.py
+++ b/osmo_jupyter/dataset_test.py
@@ -408,6 +408,7 @@ class TestOpenAndCombineSourceData:
                         "ROI 0 g_msorm": 0.6,
                         "ROI 1 g_msorm": 0.3,
                         "image": "image-1.jpeg",
+                        "PicoLog Temperature Ave. (C)": 39.75,
                         "experiment": experiment_name,
                     }
                 ]

--- a/osmo_jupyter/dataset_test.py
+++ b/osmo_jupyter/dataset_test.py
@@ -15,10 +15,26 @@ TEST_PICOLOG_DATA = pd.DataFrame(
 
 TEST_CALIBRATION_DATA = pd.DataFrame(
     [
-        {"timestamp": "2019-01-01 00:00:00.1", "equilibration status": "waiting"},
-        {"timestamp": "2019-01-01 00:00:01.1", "equilibration status": "equilibrated"},
-        {"timestamp": "2019-01-01 00:00:03.1", "equilibration status": "equilibrated"},
-        {"timestamp": "2019-01-01 00:00:04.1", "equilibration status": "waiting"},
+        {
+            "timestamp": "2019-01-01 00:00:00.1",
+            "equilibration status": "waiting",
+            "setpoint temperature": 40,
+        },
+        {
+            "timestamp": "2019-01-01 00:00:01.1",
+            "equilibration status": "equilibrated",
+            "setpoint temperature": 40,
+        },
+        {
+            "timestamp": "2019-01-01 00:00:03.1",
+            "equilibration status": "equilibrated",
+            "setpoint temperature": 40,
+        },
+        {
+            "timestamp": "2019-01-01 00:00:04.1",
+            "equilibration status": "waiting",
+            "setpoint temperature": 40,
+        },
     ]
 )
 
@@ -105,21 +121,25 @@ class TestOpenAndCombineSensorData:
                 {
                     "timestamp": "2019-01-01 00:00:00",
                     "equilibration status": "waiting",
+                    "setpoint temperature": 40,
                     "PicoLog Temperature Ave. (C)": 39,
                 },
                 {
                     "timestamp": "2019-01-01 00:00:01",
                     "equilibration status": "equilibrated",
+                    "setpoint temperature": 40,
                     "PicoLog Temperature Ave. (C)": 39.5,
                 },
                 {
                     "timestamp": "2019-01-01 00:00:03",
                     "equilibration status": "equilibrated",
+                    "setpoint temperature": 40,
                     "PicoLog Temperature Ave. (C)": 40,
                 },
                 {
                     "timestamp": "2019-01-01 00:00:04",
                     "equilibration status": "waiting",
+                    "setpoint temperature": 40,
                     "PicoLog Temperature Ave. (C)": 40,
                 },
             ]
@@ -408,7 +428,8 @@ class TestOpenAndCombineSourceData:
                         "ROI 0 g_msorm": 0.6,
                         "ROI 1 g_msorm": 0.3,
                         "image": "image-1.jpeg",
-                        "PicoLog Temperature Ave. (C)": 39.75,
+                        "PicoLog Temperature Ave. (C)": 40,
+                        "setpoint temperature": 40,
                         "experiment": experiment_name,
                     }
                 ]


### PR DESCRIPTION
[Asana Ticket](https://app.asana.com/0/819671808102776/1137324533382466)

Joins picolog and calibration environment data back on to image ROI data in `open_and_combine_and_filter_source_data`. Previously it was only using the calibration data to filter out unequilibrated data.

## Manual Testing
Fiddled with this in a notebook, but updated the test to check for this.
