### PR TITLE
Add function to open and clean up any data file

### DIFF
--- a/osmo_jupyter/dataset.py
+++ b/osmo_jupyter/dataset.py
@@ -33,13 +33,14 @@ def _apply_parser_configuration(
 
 
 def parse_ysi_kordss_file(filepath: str) -> pd.DataFrame:
-    """ Open a YSI KorDSS formatted csv file, with standardized datetime column parsing.
+    """ Open and format a YSI KorDSS formatted csv file, with standardized datetime parsing
+        and cleaned up columns.
 
         Args:
             filepath: Filepath to a YSI KorDSS csv file.
         Returns:
-            Pandas DataFrame of the raw data, with DATE and TIME columns
-            parsed together into a DATE_TIME column with a datetime dtype.
+            Pandas DataFrame of the data, with DATE and TIME columns parsed together,
+            and standardized column names.
     """
     parse_config = {
         "rename": {
@@ -59,12 +60,14 @@ def parse_ysi_kordss_file(filepath: str) -> pd.DataFrame:
 
 
 def parse_ysi_classic_file(filepath: str) -> pd.DataFrame:
-    """ Open a YSI "classic" csv file, with standardized datetime column parsing.
+    """ Open and format a YSI "classic" csv file, with standardized datetime parsing
+        and cleaned up columns.
 
         Args:
             filepath: Filepath to a YSI csv file.
         Returns:
-            Pandas DataFrame of the raw data, with Timestamp column parsed as a datetime dtype.
+            Pandas DataFrame of the data, with Timestamp column parsed as a datetime dtype,
+            and standardized column names.
     """
     parse_config = {
         "rename": {
@@ -83,13 +86,14 @@ def parse_ysi_classic_file(filepath: str) -> pd.DataFrame:
 
 
 def parse_picolog_file(filepath: str) -> pd.DataFrame:
-    """ Open a PicoLog csv file, with standardized datetime column parsing.
+    """ Open and format a PicoLog csv file, with standardized datetime parsing
+        and cleaned up columns.
 
         Args:
             filepath: Filepath to a PicoLog csv file.
         Returns:
-            Pandas DataFrame of the raw data, with the unlabeled timestamp column parsed
-            as a datetime dtype with the timezone stripped.
+            Pandas DataFrame of the data, with the unlabeled timestamp column parsed
+            as a datetime dtype with the timezone stripped, and standardized column names.
     """
     parse_config = {
         "rename": {
@@ -110,7 +114,7 @@ def parse_picolog_file(filepath: str) -> pd.DataFrame:
 
 
 def parse_calibration_log_file(filepath: str) -> pd.DataFrame:
-    """ Open a calibration log csv file, with standardized datetime column parsing.
+    """ Open and format a calibration log csv file, with standardized datetime parsing.
 
         Args:
             filepath: Filepath to a PicoLog csv file.

--- a/osmo_jupyter/dataset.py
+++ b/osmo_jupyter/dataset.py
@@ -15,129 +15,10 @@ DO_MGL = "DO (mg/L)"
 
 class DataFileType(Enum):
     UNKNOWN = 0
-    YSI_CSV = 1
+    YSI_CLASSIC = 1
     YSI_KORDSS = 2
     PICOLOG = 3
     CALIBRATION_LOG = 4
-
-
-def read_ysi_kordss_file(filepath: str) -> pd.DataFrame:
-    """ Open a YSI KorDSS formatted csv file, with standardized datetime column parsing.
-
-        Args:
-            filepath: Filepath to a YSI KorDSS csv file.
-        Returns:
-            Pandas DataFrame of the raw data, with DATE and TIME columns
-            parsed together into a DATE_TIME column with a datetime dtype.
-    """
-    return pd.read_csv(
-        filepath, skiprows=5, encoding="latin-1", parse_dates=[["DATE", "TIME"]]
-    )
-
-
-def read_ysi_csv_file(filepath: str) -> pd.DataFrame:
-    """ Open a YSI "classic" csv file, with standardized datetime column parsing.
-
-        Args:
-            filepath: Filepath to a YSI csv file.
-        Returns:
-            Pandas DataFrame of the raw data, with Timestamp column parsed as a datetime dtype.
-    """
-    return pd.read_csv(filepath, parse_dates=["Timestamp"])
-
-
-def read_picolog_file(filepath: str) -> pd.DataFrame:
-    """ Open a PicoLog csv file, with standardized datetime column parsing.
-
-        Args:
-            filepath: Filepath to a PicoLog csv file.
-        Returns:
-            Pandas DataFrame of the raw data, with the unlabeled timestamp column parsed
-            as a datetime dtype with the timezone stripped.
-    """
-    return pd.read_csv(
-        filepath,
-        parse_dates=[0],
-        date_parser=lambda col: pd.to_datetime(col, utc=False).tz_localize(None),
-    )
-
-
-def read_calibration_log_file(filepath: str) -> pd.DataFrame:
-    """ Open a calibration log csv file, with standardized datetime column parsing.
-
-        Args:
-            filepath: Filepath to a PicoLog csv file.
-        Returns:
-            Pandas DataFrame of the raw data, with timestamp column parsed
-            as a datetime dtype with fractional seconds truncated.
-    """
-    return pd.read_csv(
-        filepath,
-        parse_dates=["timestamp"],
-        date_parser=lambda col: pd.to_datetime(col, utc=False).strftime(
-            "%Y-%m-%d %H:%M:%S"
-        ),  # Truncate fractional seconds
-    )
-
-
-# Configure how each type of file we handle should be opened and transformed
-FILE_FORMAT_CONFIG = {
-    DataFileType.YSI_CSV: {
-        "rename": {
-            "Timestamp": TIMESTAMP,
-            "Barometer (mmHg)": BAROMETRIC_PRESSURE_MMHG,
-            "Dissolved Oxygen (%)": DO_PCT,
-            "Temperature (C)": TEMPERATURE_C,
-            "Unit ID": "unit ID",
-        },
-        "drop": ["Comment", "Site", "Folder"],
-        "prefix": "YSI ",
-        "parser": read_ysi_csv_file,
-    },
-    DataFileType.YSI_KORDSS: {
-        "rename": {
-            "DATE_TIME": TIMESTAMP,
-            "Barometer (mmHg)": BAROMETRIC_PRESSURE_MMHG,
-            "ODO (% Sat)": DO_PCT,
-            "ODO (mg/L)": DO_MGL,
-            "Temp (°C)": TEMPERATURE_C,
-        },
-        "drop": ["SITE", "DATA ID", "ODO (% Local)"],
-        "prefix": "YSI ",
-        "parser": read_ysi_kordss_file,
-    },
-    DataFileType.PICOLOG: {
-        "rename": {
-            "Unnamed: 0": TIMESTAMP,
-            "Temperature Ave. (C)": TEMPERATURE_C,
-            "Pressure Ave. (mmHg)": BAROMETRIC_PRESSURE_MMHG,
-        },
-        "drop": ["Pressure (Voltage) Ave. (nV)"],
-        "prefix": "PicoLog ",
-        "parser": read_picolog_file,
-    },
-    DataFileType.CALIBRATION_LOG: {
-        "rename": {},
-        "drop": [],
-        "prefix": "",
-        "parser": read_calibration_log_file,
-    },
-}
-
-
-def _infer_filetype(filename: str) -> str:
-    with open(filename, "r") as file:
-        try:
-            header = file.readline()
-            if "Dissolved Oxygen (%)" in header:
-                return DataFileType.YSI_CSV
-            elif "Pressure (Voltage) Ave." in header:
-                return DataFileType.PICOLOG
-            elif "O2 source gas gas ID" in header:
-                return DataFileType.CALIBRATION_LOG
-        except UnicodeDecodeError:
-            return DataFileType.YSI_KORDSS
-    return DataFileType.UNKNOWN
 
 
 def _apply_parser_configuration(
@@ -151,56 +32,102 @@ def _apply_parser_configuration(
     )
 
 
-def read_and_format_data_file(
-    filepath: str, filetype: DataFileType = DataFileType.UNKNOWN
-) -> pd.DataFrame:
-    """
-        Open and format any of the following supported data file types with standardized column names:
-        Original YSI csv, KorDSS YSI csv, PicoLog csv, calibration log csv
+def parse_ysi_kordss_file(filepath: str) -> pd.DataFrame:
+    """ Open a YSI KorDSS formatted csv file, with standardized datetime column parsing.
 
         Args:
-            filepath: Filepath to the file to be opened and formatted.
-            filetype: Optional. Provide the DataFileType if it is known. Otherwise the filetype will be inferred.
-    """
-    if filetype is DataFileType.UNKNOWN:
-        filetype = _infer_filetype(filepath)
-    parse_config = FILE_FORMAT_CONFIG[filetype]
-    parse_function = parse_config["parser"]
-
-    dataset = parse_function(filepath)
-
-    return _apply_parser_configuration(dataset, parse_config)
-
-
-def open_picolog_file(picolog_filepath: str) -> pd.DataFrame:
-    """
-        Open and parse a PicoLog data file such that the timestamps can be joined with calibration environment data.
-
-        Args:
-            picolog_filepath: A filepath to a PicoLog csv data file
+            filepath: Filepath to a YSI KorDSS csv file.
         Returns:
-            DataFrame of PicoLog file contents, with timestamp indexes and PicoLog prefix on all other columns,
-            upsampled and linearly interpolated to each intermediate second.
+            Pandas DataFrame of the raw data, with DATE and TIME columns
+            parsed together into a DATE_TIME column with a datetime dtype.
     """
-    return (
-        read_and_format_data_file(picolog_filepath, DataFileType.PICOLOG)
-        .resample("s")
-        .interpolate(method="slinear")
+    parse_config = {
+        "rename": {
+            "DATE_TIME": TIMESTAMP,
+            "Barometer (mmHg)": BAROMETRIC_PRESSURE_MMHG,
+            "ODO (% Sat)": DO_PCT,
+            "ODO (mg/L)": DO_MGL,
+            "Temp (°C)": TEMPERATURE_C,
+        },
+        "drop": ["SITE", "DATA ID", "ODO (% Local)"],
+        "prefix": "YSI ",
+    }
+    raw_data = pd.read_csv(
+        filepath, skiprows=5, encoding="latin-1", parse_dates=[["DATE", "TIME"]]
+    )
+    return _apply_parser_configuration(raw_data, parse_config)
+
+
+def parse_ysi_classic_file(filepath: str) -> pd.DataFrame:
+    """ Open a YSI "classic" csv file, with standardized datetime column parsing.
+
+        Args:
+            filepath: Filepath to a YSI csv file.
+        Returns:
+            Pandas DataFrame of the raw data, with Timestamp column parsed as a datetime dtype.
+    """
+    parse_config = {
+        "rename": {
+            "Timestamp": TIMESTAMP,
+            "Barometer (mmHg)": BAROMETRIC_PRESSURE_MMHG,
+            "Dissolved Oxygen (%)": DO_PCT,
+            "Temperature (C)": TEMPERATURE_C,
+            "Unit ID": "unit ID",
+        },
+        "drop": ["Comment", "Site", "Folder"],
+        "prefix": "YSI ",
+    }
+
+    raw_data = pd.read_csv(filepath, parse_dates=["Timestamp"])
+    return _apply_parser_configuration(raw_data, parse_config)
+
+
+def parse_picolog_file(filepath: str) -> pd.DataFrame:
+    """ Open a PicoLog csv file, with standardized datetime column parsing.
+
+        Args:
+            filepath: Filepath to a PicoLog csv file.
+        Returns:
+            Pandas DataFrame of the raw data, with the unlabeled timestamp column parsed
+            as a datetime dtype with the timezone stripped.
+    """
+    parse_config = {
+        "rename": {
+            "Unnamed: 0": TIMESTAMP,
+            "Temperature Ave. (C)": TEMPERATURE_C,
+            "Pressure Ave. (mmHg)": BAROMETRIC_PRESSURE_MMHG,
+        },
+        "drop": ["Pressure (Voltage) Ave. (nV)"],
+        "prefix": "PicoLog ",
+    }
+    raw_data = pd.read_csv(
+        filepath,
+        parse_dates=[0],
+        date_parser=lambda col: pd.to_datetime(col, utc=False).tz_localize(None),
     )
 
+    return _apply_parser_configuration(raw_data, parse_config)
 
-def open_calibration_log_file(calibration_log_filepath: str) -> pd.DataFrame:
-    """
-        Open and parse a calibration environment data file such that the timestamps can be joined with PicoLog data.
+
+def parse_calibration_log_file(filepath: str) -> pd.DataFrame:
+    """ Open a calibration log csv file, with standardized datetime column parsing.
 
         Args:
-            calibration_log_filepath: A filepath to a calibration environment csv data log file.
+            filepath: Filepath to a PicoLog csv file.
         Returns:
-            DataFrame of calibration data file contents, with timestamp indexes.
+            Pandas DataFrame of the raw data, with timestamp column parsed
+            as a datetime dtype with fractional seconds truncated.
     """
-    return read_and_format_data_file(
-        calibration_log_filepath, DataFileType.CALIBRATION_LOG
+    parse_config = {"rename": {}, "drop": [], "prefix": ""}
+    raw_data = pd.read_csv(
+        filepath,
+        parse_dates=["timestamp"],
+        date_parser=lambda col: pd.to_datetime(col, utc=False).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        ),  # Truncate fractional seconds
     )
+
+    return _apply_parser_configuration(raw_data, parse_config)
 
 
 def open_and_combine_picolog_and_calibration_data(
@@ -218,7 +145,9 @@ def open_and_combine_picolog_and_calibration_data(
     """
     picolog_data = pd.concat(
         [
-            open_picolog_file(picolog_filepath)
+            parse_picolog_file(picolog_filepath)
+            .resample("s")
+            .interpolate(method="slinear")
             for picolog_filepath in picolog_log_filepaths
         ],
         sort=True,
@@ -226,7 +155,7 @@ def open_and_combine_picolog_and_calibration_data(
 
     calibration_data = pd.concat(
         [
-            open_calibration_log_file(calibration_log_filepath)
+            parse_calibration_log_file(calibration_log_filepath)
             for calibration_log_filepath in calibration_log_filepaths
         ],
         sort=True,
@@ -430,7 +359,9 @@ def open_and_combine_and_filter_source_data(
 
     picolog_data = pd.concat(
         [
-            open_picolog_file(picolog_filepath)
+            parse_picolog_file(picolog_filepath)
+            .resample("s")
+            .interpolate(method="slinear")
             for picolog_filepath in picolog_log_filepaths
         ],
         sort=True,
@@ -438,7 +369,7 @@ def open_and_combine_and_filter_source_data(
 
     calibration_data = pd.concat(
         [
-            open_calibration_log_file(calibration_log_filepath)
+            parse_calibration_log_file(calibration_log_filepath)
             for calibration_log_filepath in calibration_log_filepaths
         ],
         sort=True,

--- a/osmo_jupyter/dataset.py
+++ b/osmo_jupyter/dataset.py
@@ -1,6 +1,5 @@
 import os
 from typing import List, Dict
-from enum import Enum
 
 import pandas as pd
 
@@ -13,18 +12,11 @@ DO_PCT = "DO (%)"
 DO_MGL = "DO (mg/L)"
 
 
-class DataFileType(Enum):
-    YSI_CLASSIC = 0
-    YSI_KORDSS = 1
-    PICOLOG = 2
-    CALIBRATION_LOG = 3
-
-
 def _apply_parser_configuration(
     dataset: pd.DataFrame, parse_config: Dict
 ) -> pd.DataFrame:
     return (
-        dataset.drop(parse_config["drop"], axis=1)
+        dataset.drop(columns=parse_config["drop"])
         .rename(columns=parse_config["rename"])
         .set_index("timestamp")
         .add_prefix(parse_config["prefix"])

--- a/osmo_jupyter/dataset.py
+++ b/osmo_jupyter/dataset.py
@@ -14,11 +14,10 @@ DO_MGL = "DO (mg/L)"
 
 
 class DataFileType(Enum):
-    UNKNOWN = 0
-    YSI_CLASSIC = 1
-    YSI_KORDSS = 2
-    PICOLOG = 3
-    CALIBRATION_LOG = 4
+    YSI_CLASSIC = 0
+    YSI_KORDSS = 1
+    PICOLOG = 2
+    CALIBRATION_LOG = 3
 
 
 def _apply_parser_configuration(

--- a/osmo_jupyter/dataset_test.py
+++ b/osmo_jupyter/dataset_test.py
@@ -156,6 +156,7 @@ class TestReadAndFormatDataFile:
 
     def test_formats_ysi_kordss_correctly(self, tmpdir):
         mock_YSI_KorDSS_file_obj = tmpdir.join("test_kordss.csv")
+        # Real KorDSS file has other contents in this header, but it adds up to 5 lines
         mock_YSI_KorDSS_file_obj.write("\n\n\n\n\n")
         TEST_YSI_KORDSS_DATA.to_csv(
             mock_YSI_KorDSS_file_obj, index=False, mode="a", encoding="latin-1"

--- a/osmo_jupyter/dataset_test.py
+++ b/osmo_jupyter/dataset_test.py
@@ -133,104 +133,106 @@ def mock_calibration_file_path(tmpdir):
     )
 
 
-class TestDataFileParsers:
-    def test_formats_ysi_csv_correctly(self, tmpdir):
-        mock_YSI_csv_file_obj = create_mock_file_path(
-            tmpdir, TEST_YSI_CSV_DATA, "test_ysi.csv"
-        )
+def test_parses_ysi_csv_correctly(tmpdir):
+    mock_YSI_csv_file_obj = create_mock_file_path(
+        tmpdir, TEST_YSI_CSV_DATA, "test_ysi.csv"
+    )
 
-        formatted_ysi_data = module.parse_ysi_classic_file(mock_YSI_csv_file_obj)
-        expected_ysi_data = pd.DataFrame(
-            [
-                {
-                    "timestamp": pd.to_datetime("2019-01-01 00:00:00"),
-                    "YSI barometric pressure (mmHg)": 750,
-                    "YSI DO (%)": 19,
-                    "YSI temperature (C)": 24.7,
-                    "YSI unit ID": "unit ID",
-                }
-            ]
-        ).set_index("timestamp")
+    formatted_ysi_data = module.parse_ysi_classic_file(mock_YSI_csv_file_obj)
+    expected_ysi_data = pd.DataFrame(
+        [
+            {
+                "timestamp": pd.to_datetime("2019-01-01 00:00:00"),
+                "YSI barometric pressure (mmHg)": 750,
+                "YSI DO (%)": 19,
+                "YSI temperature (C)": 24.7,
+                "YSI unit ID": "unit ID",
+            }
+        ]
+    ).set_index("timestamp")
 
-        pd.testing.assert_frame_equal(formatted_ysi_data, expected_ysi_data)
+    pd.testing.assert_frame_equal(formatted_ysi_data, expected_ysi_data)
 
-    def test_formats_ysi_kordss_correctly(self, tmpdir):
-        mock_YSI_KorDSS_file_path = tmpdir.join("test_kordss.csv")
-        # Real KorDSS file has other contents in this header, but it adds up to 5 lines
-        mock_YSI_KorDSS_file_path.write("\n\n\n\n\n")
-        TEST_YSI_KORDSS_DATA.to_csv(
-            mock_YSI_KorDSS_file_path, index=False, mode="a", encoding="latin-1"
-        )
 
-        formatted_ysi_data = module.parse_ysi_kordss_file(mock_YSI_KorDSS_file_path)
-        expected_ysi_data = pd.DataFrame(
-            [
-                {
-                    "timestamp": pd.to_datetime("2019-01-01 00:00:00"),
-                    "YSI barometric pressure (mmHg)": 750,
-                    "YSI DO (%)": 60,
-                    "YSI DO (mg/L)": 6,
-                    "YSI temperature (C)": 24.7,
-                }
-            ]
-        ).set_index("timestamp")
+def test_parses_ysi_kordss_correctly(tmpdir):
+    mock_YSI_KorDSS_file_path = tmpdir.join("test_kordss.csv")
+    # Real KorDSS file has other contents in this header, but it adds up to 5 lines
+    mock_YSI_KorDSS_file_path.write("\n\n\n\n\n")
+    TEST_YSI_KORDSS_DATA.to_csv(
+        mock_YSI_KorDSS_file_path, index=False, mode="a", encoding="latin-1"
+    )
 
-        pd.testing.assert_frame_equal(formatted_ysi_data, expected_ysi_data)
+    formatted_ysi_data = module.parse_ysi_kordss_file(mock_YSI_KorDSS_file_path)
+    expected_ysi_data = pd.DataFrame(
+        [
+            {
+                "timestamp": pd.to_datetime("2019-01-01 00:00:00"),
+                "YSI barometric pressure (mmHg)": 750,
+                "YSI DO (%)": 60,
+                "YSI DO (mg/L)": 6,
+                "YSI temperature (C)": 24.7,
+            }
+        ]
+    ).set_index("timestamp")
 
-    def test_formats_picolog_csv_correctly(self, mock_picolog_file_path):
-        formatted_picolog_data = module.parse_picolog_file(mock_picolog_file_path)
-        expected_picolog_data = pd.DataFrame(
-            [
-                {
-                    "timestamp": pd.to_datetime("2019-01-01 00:00:00"),
-                    "PicoLog temperature (C)": 39,
-                },
-                {
-                    "timestamp": pd.to_datetime("2019-01-01 00:00:02"),
-                    "PicoLog temperature (C)": 40,
-                },
-                {
-                    "timestamp": pd.to_datetime("2019-01-01 00:00:04"),
-                    "PicoLog temperature (C)": 40,
-                },
-            ]
-        ).set_index("timestamp")
+    pd.testing.assert_frame_equal(formatted_ysi_data, expected_ysi_data)
 
-        pd.testing.assert_frame_equal(formatted_picolog_data, expected_picolog_data)
 
-    def test_formats_calibration_log_correctly(self, mock_calibration_file_path):
-        formatted_calibration_log_data = module.parse_calibration_log_file(
-            mock_calibration_file_path
-        )
-        # Nothing is supposed to be renamed or dropped, just datetime formatting
-        expected_calibration_log_data = pd.DataFrame(
-            [
-                {
-                    "timestamp": pd.to_datetime("2019-01-01 00:00:00"),
-                    "equilibration status": "waiting",
-                    "setpoint temperature": 40,
-                },
-                {
-                    "timestamp": pd.to_datetime("2019-01-01 00:00:01"),
-                    "equilibration status": "equilibrated",
-                    "setpoint temperature": 40,
-                },
-                {
-                    "timestamp": pd.to_datetime("2019-01-01 00:00:03"),
-                    "equilibration status": "equilibrated",
-                    "setpoint temperature": 40,
-                },
-                {
-                    "timestamp": pd.to_datetime("2019-01-01 00:00:04"),
-                    "equilibration status": "waiting",
-                    "setpoint temperature": 40,
-                },
-            ]
-        ).set_index("timestamp")
+def test_parses_picolog_csv_correctly(mock_picolog_file_path):
+    formatted_picolog_data = module.parse_picolog_file(mock_picolog_file_path)
+    expected_picolog_data = pd.DataFrame(
+        [
+            {
+                "timestamp": pd.to_datetime("2019-01-01 00:00:00"),
+                "PicoLog temperature (C)": 39,
+            },
+            {
+                "timestamp": pd.to_datetime("2019-01-01 00:00:02"),
+                "PicoLog temperature (C)": 40,
+            },
+            {
+                "timestamp": pd.to_datetime("2019-01-01 00:00:04"),
+                "PicoLog temperature (C)": 40,
+            },
+        ]
+    ).set_index("timestamp")
 
-        pd.testing.assert_frame_equal(
-            formatted_calibration_log_data, expected_calibration_log_data
-        )
+    pd.testing.assert_frame_equal(formatted_picolog_data, expected_picolog_data)
+
+
+def test_parses_calibration_log_correctly(mock_calibration_file_path):
+    formatted_calibration_log_data = module.parse_calibration_log_file(
+        mock_calibration_file_path
+    )
+    # Nothing is supposed to be renamed or dropped, just datetime formatting
+    expected_calibration_log_data = pd.DataFrame(
+        [
+            {
+                "timestamp": pd.to_datetime("2019-01-01 00:00:00"),
+                "equilibration status": "waiting",
+                "setpoint temperature": 40,
+            },
+            {
+                "timestamp": pd.to_datetime("2019-01-01 00:00:01"),
+                "equilibration status": "equilibrated",
+                "setpoint temperature": 40,
+            },
+            {
+                "timestamp": pd.to_datetime("2019-01-01 00:00:03"),
+                "equilibration status": "equilibrated",
+                "setpoint temperature": 40,
+            },
+            {
+                "timestamp": pd.to_datetime("2019-01-01 00:00:04"),
+                "equilibration status": "waiting",
+                "setpoint temperature": 40,
+            },
+        ]
+    ).set_index("timestamp")
+
+    pd.testing.assert_frame_equal(
+        formatted_calibration_log_data, expected_calibration_log_data
+    )
 
 
 class TestOpenAndCombineSensorData:

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,9 @@ setup(
         "numpy",
         "pandas",
         "petl",
-        "plotly >= 4, < 5",
+        # Pin plotly version until skimage dependency is fixed
+        # https://github.com/plotly/plotly.py/issues/1829
+        "plotly==4.1.1",
         "pymysql",
         "requests",
         "scipy",

--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,7 @@ setup(
         "numpy",
         "pandas",
         "petl",
-        # Pin plotly version until skimage dependency is fixed
-        # https://github.com/plotly/plotly.py/issues/1829
-        "plotly==4.1.1",
+        "plotly >= 4, < 5",
         "pymysql",
         "requests",
         "scipy",


### PR DESCRIPTION
[Asana Ticket](https://app.asana.com/0/819671808102776/1144794081013111)

Adds a helper function that can identify and open any of our typical data files from calibration or scum tank data collection. Also cleans up column names and timestamps to be standardized across files, mostly using the calibration log files as the baseline.

The way it's structured is such that the actual opening of the files is done in separate functions, and there's one wrapper function which will attempt to infer the filetype (or you can skip that and just tell it) and then apply necessary transformations. The type inference feels kind of fragile, and like an over-the-top convenience, so I'd also be happy cutting it out.

## Manual Testing
Ran this code with real files and checked the output:
```python
files = [
    "YSI_data.csv",
    "2019-10-09_pico.csv",
    "2019-10-11--19-41-03_calibration.csv",
    "KorDSS Measurement File Export - 101119 214237.csv",
]
for file in files:
    display(read_and_format_data_file(file).head())
```
