### PR TITLE
Bugfix: Pivot process experiment results before concat

### DIFF
--- a/osmo_jupyter/dataset/combine.py
+++ b/osmo_jupyter/dataset/combine.py
@@ -86,7 +86,7 @@ def get_equilibration_boundaries(equilibration_status: pd.Series) -> pd.DataFram
 def pivot_process_experiment_results_on_ROI(
     experiment_df: pd.DataFrame,
     ROI_names: List[str] = None,
-    msorm_types: List[str] = None,
+    pivot_values: List[str] = None,
 ) -> pd.DataFrame:
     """
         Flatten a DataFrame of process experiment results down to one row per image.
@@ -94,13 +94,14 @@ def pivot_process_experiment_results_on_ROI(
         Args:
             experiment_df: A DataFrame of process experiment summary statistics.
             ROI_names: Optional. A list of ROI names to select. Defaults to all ROIs present.
-            msorm_types: Optional. A list of MSORM column names to select. Defaults to all RGB channel MSORMs.
+            pivot_values: Optional. A list of column names to select for each ROI in the pivot.
+                Defaults to all RGB channel MSORMs.
         Returns:
             DataFrame with one row per image, and msorm values for a subset of ROIs. Creates one column
             for every unique ROI in the dataset. NaN values are used when an image is missing an ROI.
     """
-    if msorm_types is None:
-        msorm_types = ["r_msorm", "g_msorm", "b_msorm"]
+    if pivot_values is None:
+        pivot_values = ["r_msorm", "g_msorm", "b_msorm"]
 
     if ROI_names:
         experiment_df = experiment_df[experiment_df["ROI"].isin(ROI_names)]
@@ -112,7 +113,7 @@ def pivot_process_experiment_results_on_ROI(
 
     # Pivot creates a heirachical multiindex data frame with an index for each 'values' column
     pivot = experiment_df.pivot(
-        index="timestamp", columns="ROI", values=msorm_types + ["image"]
+        index="timestamp", columns="ROI", values=pivot_values + ["image"]
     )
 
     # After pivot -> Multi-level index
@@ -141,7 +142,7 @@ def pivot_process_experiment_results_on_ROI(
 def open_and_combine_process_experiment_results(
     process_experiment_result_filepaths: List[str],
     ROI_names: List[str] = None,
-    msorm_types: List[str] = None,
+    pivot_values: List[str] = None,
 ) -> pd.DataFrame:
     """
         Open multiple process experiment result files and combine into a single DataFrame with one row per image.
@@ -149,21 +150,26 @@ def open_and_combine_process_experiment_results(
         Args:
             process_experiment_result_filepaths: A list of filepaths to process experiment summary statistics files.
             ROI_names: Optional. A list of ROI names to select. Defaults to all ROIs present.
-            msorm_types: Optional. A list of MSORM column names to select. Defaults to all RGB channel MSORMs.
+            pivot_values: Optional. A list of column names to select for each ROI in the pivot.
+                Defaults to all RGB channel MSORMs.
         Returns:
             DataFrame of all summary statistics flattened to one row per image with all selected ROIs.
     """
-    if msorm_types is None:
-        msorm_types = ["r_msorm", "g_msorm", "b_msorm"]
+    if pivot_values is None:
+        pivot_values = ["r_msorm", "g_msorm", "b_msorm"]
 
     all_roi_data = pd.concat(
         [
-            pd.read_csv(results_filepath, parse_dates=["timestamp"])
+            pivot_process_experiment_results_on_ROI(
+                pd.read_csv(results_filepath, parse_dates=["timestamp"]),
+                ROI_names,
+                pivot_values,
+            )
             for results_filepath in process_experiment_result_filepaths
         ]
     )
 
-    return pivot_process_experiment_results_on_ROI(all_roi_data, ROI_names, msorm_types)
+    return all_roi_data
 
 
 def filter_equilibrated_images(equilibration_range: pd.Series, df: pd.DataFrame):

--- a/osmo_jupyter/dataset/combine.py
+++ b/osmo_jupyter/dataset/combine.py
@@ -86,7 +86,7 @@ def get_equilibration_boundaries(equilibration_status: pd.Series) -> pd.DataFram
 def pivot_process_experiment_results_on_ROI(
     experiment_df: pd.DataFrame,
     ROI_names: List[str] = None,
-    pivot_values: List[str] = None,
+    pivot_column_names: List[str] = None,
 ) -> pd.DataFrame:
     """
         Flatten a DataFrame of process experiment results down to one row per image.
@@ -94,14 +94,14 @@ def pivot_process_experiment_results_on_ROI(
         Args:
             experiment_df: A DataFrame of process experiment summary statistics.
             ROI_names: Optional. A list of ROI names to select. Defaults to all ROIs present.
-            pivot_values: Optional. A list of column names to select for each ROI in the pivot.
+            pivot_column_names: Optional. A list of column names to select for each ROI in the pivot.
                 Defaults to all RGB channel MSORMs.
         Returns:
-            DataFrame with one row per image, and msorm values for a subset of ROIs. Creates one column
+            DataFrame with one row per image, and pivot-column values for a subset of ROIs. Creates one column
             for every unique ROI in the dataset. NaN values are used when an image is missing an ROI.
     """
-    if pivot_values is None:
-        pivot_values = ["r_msorm", "g_msorm", "b_msorm"]
+    if pivot_column_names is None:
+        pivot_column_names = ["r_msorm", "g_msorm", "b_msorm"]
 
     if ROI_names:
         experiment_df = experiment_df[experiment_df["ROI"].isin(ROI_names)]
@@ -113,7 +113,7 @@ def pivot_process_experiment_results_on_ROI(
 
     # Pivot creates a heirachical multiindex data frame with an index for each 'values' column
     pivot = experiment_df.pivot(
-        index="timestamp", columns="ROI", values=pivot_values + ["image"]
+        index="timestamp", columns="ROI", values=pivot_column_names + ["image"]
     )
 
     # After pivot -> Multi-level index
@@ -142,7 +142,7 @@ def pivot_process_experiment_results_on_ROI(
 def open_and_combine_process_experiment_results(
     process_experiment_result_filepaths: List[str],
     ROI_names: List[str] = None,
-    pivot_values: List[str] = None,
+    pivot_column_names: List[str] = None,
 ) -> pd.DataFrame:
     """
         Open multiple process experiment result files and combine into a single DataFrame with one row per image.
@@ -150,20 +150,18 @@ def open_and_combine_process_experiment_results(
         Args:
             process_experiment_result_filepaths: A list of filepaths to process experiment summary statistics files.
             ROI_names: Optional. A list of ROI names to select. Defaults to all ROIs present.
-            pivot_values: Optional. A list of column names to select for each ROI in the pivot.
+            pivot_column_names: Optional. A list of column names to select for each ROI in the pivot.
                 Defaults to all RGB channel MSORMs.
         Returns:
             DataFrame of all summary statistics flattened to one row per image with all selected ROIs.
     """
-    if pivot_values is None:
-        pivot_values = ["r_msorm", "g_msorm", "b_msorm"]
 
     all_roi_data = pd.concat(
         [
             pivot_process_experiment_results_on_ROI(
                 pd.read_csv(results_filepath, parse_dates=["timestamp"]),
                 ROI_names,
-                pivot_values,
+                pivot_column_names,
             )
             for results_filepath in process_experiment_result_filepaths
         ]

--- a/osmo_jupyter/dataset/combine_test.py
+++ b/osmo_jupyter/dataset/combine_test.py
@@ -235,7 +235,7 @@ class TestPivotProcessExperimentResults:
         pivot_results = module.pivot_process_experiment_results_on_ROI(
             experiment_df=test_process_experiment_data,
             ROI_names=list(test_process_experiment_data["ROI"].unique()),
-            pivot_values=["r_msorm", "g_msorm"],
+            pivot_column_names=["r_msorm", "g_msorm"],
         )
 
         expected_results_data = (
@@ -267,7 +267,7 @@ class TestPivotProcessExperimentResults:
 
 
 class TestOpenAndCombineProcessExperimentResults:
-    def test_does_not_throw_on_simultaneous_timestamps(self):
+    def test_keeps_distinct_rows_for_images_with_same_timestamp(self):
         test_process_experiment_file_path = pkg_resources.resource_filename(
             "osmo_jupyter", "test_fixtures/test_process_experiment_result.csv"
         )
@@ -280,7 +280,6 @@ class TestOpenAndCombineProcessExperimentResults:
             ]
         )
 
-        # Bonus assertion - make sure we preserve duplicate rows for each timestamp
         unique_timestamps = pivot_results.index.unique()
         assert len(unique_timestamps) == len(pivot_results) / 2
 

--- a/osmo_jupyter/dataset/combine_test.py
+++ b/osmo_jupyter/dataset/combine_test.py
@@ -235,7 +235,7 @@ class TestPivotProcessExperimentResults:
         pivot_results = module.pivot_process_experiment_results_on_ROI(
             experiment_df=test_process_experiment_data,
             ROI_names=list(test_process_experiment_data["ROI"].unique()),
-            msorm_types=["r_msorm", "g_msorm"],
+            pivot_values=["r_msorm", "g_msorm"],
         )
 
         expected_results_data = (
@@ -264,6 +264,25 @@ class TestPivotProcessExperimentResults:
         )
 
         pd.testing.assert_frame_equal(pivot_results, expected_results_data)
+
+
+class TestOpenAndCombineProcessExperimentResults:
+    def test_does_not_throw_on_simultaneous_timestamps(self):
+        test_process_experiment_file_path = pkg_resources.resource_filename(
+            "osmo_jupyter", "test_fixtures/test_process_experiment_result.csv"
+        )
+
+        # Open the same file twice to ensure there are duplicate timestamps
+        pivot_results = module.open_and_combine_process_experiment_results(
+            process_experiment_result_filepaths=[
+                test_process_experiment_file_path,
+                test_process_experiment_file_path,
+            ]
+        )
+
+        # Bonus assertion - make sure we preserve duplicate rows for each timestamp
+        unique_timestamps = pivot_results.index.unique()
+        assert len(unique_timestamps) == len(pivot_results) / 2
 
 
 class TestFilterEquilibratedImages:


### PR DESCRIPTION
[Asana Ticket](https://app.asana.com/0/819671808102776/1148728220755426)

If we concat multiple experiment results files before pivoting, the pivot blows up if there are duplicate timestamps in the index (as there are when we collect on multiple units simultaneously). 

Fix here is to pivot each file individually and then concat them.

## Manual Testing

Ran the modified function with a list of result files from attempt 19 (units E and D collected data simultaneously). Checked that the output dataframe had the same number of rows as if each file had been passed in individually and concatenated afterward, also verified that the combined dataframe had rows for distinct images taken during the same second.

<img width="899" alt="Screen Shot 2019-11-19 at 11 21 30 AM" src="https://user-images.githubusercontent.com/1757661/69164911-c5fd5780-0abe-11ea-95fb-c1ab24f12aee.png">


