### PR TITLE
Parse data collection log with missing s3 buckets

### DIFF
--- a/osmo_jupyter/dataset/parse.py
+++ b/osmo_jupyter/dataset/parse.py
@@ -198,8 +198,13 @@ def parse_calibration_log_file(filepath: str) -> pd.DataFrame:
 
 
 def _get_attempt_summary(attempt: pd.Series) -> pd.Series:
-    experiment_names = attempt["S3 Bucket(s)"].split("\n")
+    if attempt.notna()["S3 Bucket(s)"]:
+        experiment_names = attempt["S3 Bucket(s)"].split("\n")
+    else:
+        experiment_names = []
+
     pond = attempt["Scum Tank"] if "Scum Tank" in attempt.index else "calibration"
+
     return pd.Series(
         {
             "experiment_names": experiment_names,

--- a/osmo_jupyter/dataset/parse.py
+++ b/osmo_jupyter/dataset/parse.py
@@ -198,10 +198,11 @@ def parse_calibration_log_file(filepath: str) -> pd.DataFrame:
 
 
 def _get_attempt_summary(attempt: pd.Series) -> pd.Series:
-    if attempt.notna()["S3 Bucket(s)"]:
-        experiment_names = attempt["S3 Bucket(s)"].split("\n")
-    else:
-        experiment_names = []
+    experiment_names = (
+        attempt["S3 Bucket(s)"].split("\n")
+        if not pd.isnull(attempt["S3 Bucket(s)"])
+        else []
+    )
 
     pond = attempt["Scum Tank"] if "Scum Tank" in attempt.index else "calibration"
 

--- a/osmo_jupyter/dataset/parse_test.py
+++ b/osmo_jupyter/dataset/parse_test.py
@@ -170,6 +170,34 @@ class TestParseDataCollectionLog:
 
         pd.testing.assert_series_equal(actual_attempt_summary, expected_attempt_summary)
 
+    def test_get_attempt_summary_handles_missing_bucket(self):
+        test_attempt_data = pd.Series(
+            {
+                "S3 Bucket(s)": None,
+                "Drive Directory": "Experiment",
+                "Cosmobot ID": "Z",
+                "Cartridge": "C1",
+                "Start Date/Time": pd.to_datetime("2019"),
+                "End Date/Time": pd.to_datetime("2020"),
+            }
+        )
+
+        actual_attempt_summary = module._get_attempt_summary(test_attempt_data)
+
+        expected_attempt_summary = pd.Series(
+            {
+                "experiment_names": [],
+                "drive_directory": "Experiment",
+                "pond": "calibration",
+                "cosmobot_id": "Z",
+                "cartridge_id": "C1",
+                "start_date": pd.to_datetime("2019"),
+                "end_date": pd.to_datetime("2020"),
+            }
+        )
+
+        pd.testing.assert_series_equal(actual_attempt_summary, expected_attempt_summary)
+
 
 def test_interpolates_calibration_log_data_correctly(mocker):
     mock_calibration_log_data = pd.DataFrame(


### PR DESCRIPTION
Related to [Automate adding attempts into dataset repo](https://app.asana.com/0/819671808102776/1148349932180749)

In putting together the notebook for the above ticket I ran into an issue with parsing the data collection log in its current state, where some rows existed for in-progress data collection with an unpopulated S3 Bucket(s) column. I figured this would be a recurring problem so I decided to take care of it in code rather than try to come up with a useful placeholder.

## Manual Testing
Used it against a snapshot of the current data collection log which exhibits this issue.

